### PR TITLE
refactor: remove `@ngneat/until-destroy`

### DIFF
--- a/apps/ng-doc/docs/writing-content/playground/floating-circle-position-control/floating-circle-position-control.component.ts
+++ b/apps/ng-doc/docs/writing-content/playground/floating-circle-position-control/floating-circle-position-control.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgDocTypeControl } from '@ng-doc/app';
 import { EMPTY_FUNCTION } from '@ng-doc/core';
@@ -7,7 +8,6 @@ import {
   NgDocInputWrapperComponent,
   NgDocLabelComponent,
 } from '@ng-doc/ui-kit';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
 import { FloatingCirclePosition } from '../floating-circle/floating-circle.component';
 
@@ -25,7 +25,6 @@ import { FloatingCirclePosition } from '../floating-circle/floating-circle.compo
     NgDocInputStringDirective,
   ],
 })
-@UntilDestroy()
 export class FloatingCirclePositionControlComponent
   implements NgDocTypeControl<FloatingCirclePosition>
 {
@@ -45,7 +44,7 @@ export class FloatingCirclePositionControlComponent
 
   constructor() {
     this.model.valueChanges
-      .pipe(untilDestroyed(this))
+      .pipe(takeUntilDestroyed())
       .subscribe((value: FloatingCirclePosition) => this.changed(value));
   }
 

--- a/apps/ng-doc/poc/api/sample.types.ts
+++ b/apps/ng-doc/poc/api/sample.types.ts
@@ -1,7 +1,6 @@
-
 export declare class DummyClass {
   /** Find the first node with the specified title */
-  public findByTitle(title: string): object;
+  findByTitle(title: string): object;
 }
 
 export type ResourceId = string;
@@ -19,16 +18,16 @@ export type ResourceVersion = number;
 /**
  * List of tags that a resource has.
  */
-export type ResourceTagList = Array<string>;
+export type ResourceTagList = string[];
 
 /**
  * Description of a resource
  */
-export type ResourceDescription = {
+export interface ResourceDescription {
   name: string;
   description?: string;
   tags?: ResourceTagList;
-};
+}
 
 export type UserRole = 'guest' | 'user';
 
@@ -46,7 +45,7 @@ export type SystemRole = UserRole | OrgUserRole | StandaloneUserRole;
  */
 export type OAuthGrantType = 'authorization_code' | 'client_credentials' | 'refresh_token';
 
-export type OAuthGrantTypes = Array<OAuthGrantType>;
+export type OAuthGrantTypes = OAuthGrantType[];
 
 /**
  * OAuth 2.0 response types used in differnt OAuth 2.0 flows. See https://oauth.net/2/.
@@ -56,7 +55,7 @@ export type OAuthResponseType = Array<'token' | 'code'>;
 /**
  * A related resource link (see hateoas principles).
  */
-export type ResourceLink = {
+export interface ResourceLink {
   href: string;
   /**
    * Indicates whether href" property is a URI Template.
@@ -70,21 +69,21 @@ export type ResourceLink = {
    * May be used as a secondary key for selecting Link Objects which share the same relation type.
    */
   name?: string;
-};
+}
 
 /**
-* hateoas object containing links to self and related resources.
-* @see HAL spec at http://stateless.co/hal_specification.html
-* @see https://tools.ietf.org/html/draft-kelly-json-hal-08
-*/
-export type HateoasLinks = {
+ * hateoas object containing links to self and related resources.
+ * @see HAL spec at http://stateless.co/hal_specification.html
+ * @see https://tools.ietf.org/html/draft-kelly-json-hal-08
+ */
+export interface HateoasLinks {
   self: ResourceLink;
   /**
    * Templates to generate links.
    */
-  curies?: Array<ResourceLink>;
-  [key: string]: (ResourceLink | Array<ResourceLink>) | ResourceLink | Array<ResourceLink> | undefined;
-};
+  curies?: ResourceLink[];
+  [key: string]: (ResourceLink | ResourceLink[]) | ResourceLink | ResourceLink[] | undefined;
+}
 
 export type HateoasEmbedded = ResourceDescription & {
   id: ResourceId;
@@ -95,17 +94,16 @@ export type HateoasEmbedded = ResourceDescription & {
 };
 
 /** */
-export type BaseApplicationAttributes = {
+export interface BaseApplicationAttributes {
   oauthGrantTypes?: OAuthGrantTypes;
   oauthResponseTypes?: OAuthResponseType;
   organisation?: ResourceId;
-};
+}
 
 /**
  * An application body.
- * 
  * @usageNotes
- * 
+ *
  * Some useful notes about the application body.
  */
 export type ApplicationBody = BaseApplicationAttributes & {
@@ -124,17 +122,17 @@ export type ApplicationBody = BaseApplicationAttributes & {
   /**
    * Callback URIs.
    */
-  callbackURIs?: Array<string>;
+  callbackURIs?: string[];
   /**
    * Allowed redirection URLs for logout.
    */
-  logoutURLs?: Array<string>;
+  logoutURLs?: string[];
   /** */
   clientCredentialsRole?: SystemRole;
   /**
    * List of scopes allowed for this application.
    */
-  allowedScopes?: Array<string>;
+  allowedScopes?: string[];
 };
 
 /**
@@ -160,11 +158,11 @@ export type BaseLinks = HateoasLinks & {
   owner?: ResourceLink;
 };
 
-export type BaseEmbedded = {
+export interface BaseEmbedded {
   creator?: HateoasEmbedded;
   modifier?: HateoasEmbedded;
   owner?: HateoasEmbedded;
-};
+}
 
 export type ApplicationLinks = BaseLinks & {
   providers?: ResourceLink;
@@ -175,9 +173,10 @@ export type ApplicationEmbedded = BaseEmbedded & {
   organisation: HateoasEmbedded;
 };
 
-export type SimpleApplicationProfile = SimpleResourceResponse & BaseApplicationAttributes & {
-  _embedded?: ApplicationEmbedded;
-  _links?: ApplicationLinks;
-};
+export type SimpleApplicationProfile = SimpleResourceResponse &
+  BaseApplicationAttributes & {
+    _embedded?: ApplicationEmbedded;
+    _links?: ApplicationLinks;
+  };
 
 export type ApplicationProfile = SimpleApplicationProfile & ApplicationBody;

--- a/apps/ng-doc/src/app/pages/landing/background/background.component.ts
+++ b/apps/ng-doc/src/app/pages/landing/background/background.component.ts
@@ -9,10 +9,9 @@ import {
   OnDestroy,
   ViewChild,
 } from '@angular/core';
-import { NgDocTheme } from '@ng-doc/app';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgDocThemeService } from '@ng-doc/app/services/theme';
 import { ngDocZoneDetach } from '@ng-doc/ui-kit';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { fromEvent } from 'rxjs';
 import { debounceTime, startWith } from 'rxjs/operators';
 
@@ -37,7 +36,6 @@ const DARK_PALETTE = [
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIf, NgFor],
 })
-@UntilDestroy()
 export class BackgroundComponent implements OnDestroy {
   @Input()
   minRadius: number = 400;
@@ -105,12 +103,12 @@ export class BackgroundComponent implements OnDestroy {
       this.animationId = window.requestAnimationFrame(this.animate.bind(this));
 
       fromEvent(window, 'resize')
-        .pipe(debounceTime(100), untilDestroyed(this), ngDocZoneDetach(this.ngZone))
+        .pipe(debounceTime(100), ngDocZoneDetach(this.ngZone), takeUntilDestroyed())
         .subscribe(() => this.resize());
 
       this.themeService
         .themeChanges()
-        .pipe(startWith(this.themeService.currentTheme), untilDestroyed(this))
+        .pipe(startWith(this.themeService.currentTheme), takeUntilDestroyed())
         .subscribe((theme: string | null) => {
           this.colors = theme ? DARK_PALETTE : LIGHT_PALETTE;
           this.resize();

--- a/libs/app/components/navbar/navbar.component.ts
+++ b/libs/app/components/navbar/navbar.component.ts
@@ -9,6 +9,7 @@ import {
   Input,
   NgZone,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgDocSearchComponent } from '@ng-doc/app/components/search';
 import { NgDocSidebarService } from '@ng-doc/app/services';
 import {
@@ -18,7 +19,6 @@ import {
   ngDocZoneOptimize,
 } from '@ng-doc/ui-kit';
 import { WINDOW } from '@ng-web-apis/common';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
 import { combineLatest, fromEvent } from 'rxjs';
 import { distinctUntilChanged, map, startWith } from 'rxjs/operators';
@@ -41,7 +41,6 @@ import { distinctUntilChanged, map, startWith } from 'rxjs/operators';
     AsyncPipe,
   ],
 })
-@UntilDestroy()
 export class NgDocNavbarComponent {
   /**
    * Show search input
@@ -90,7 +89,7 @@ export class NgDocNavbarComponent {
             ([scrolled, isExpanded]: [boolean, boolean]) =>
               scrolled || (isExpanded && this.sidebarService.isMobile),
           ),
-          untilDestroyed(this),
+          takeUntilDestroyed(),
         )
         .subscribe((hasShadow: boolean) => {
           this.hasBorder = hasShadow;

--- a/libs/app/components/page/page.component.ts
+++ b/libs/app/components/page/page.component.ts
@@ -34,7 +34,6 @@ import {
   NgDocTextRightDirective,
   NgDocTooltipDirective,
 } from '@ng-doc/ui-kit';
-import { UntilDestroy } from '@ngneat/until-destroy';
 
 @Component({
   selector: 'ng-doc-page',
@@ -65,7 +64,6 @@ import { UntilDestroy } from '@ngneat/until-destroy';
   ],
   host: { ngSkipHydration: 'true' },
 })
-@UntilDestroy()
 export class NgDocPageComponent {
   @ViewChild('pageContainer', { read: ElementRef, static: true })
   pageContainer!: ElementRef<HTMLElement>;

--- a/libs/app/components/playground/playground-demo/playground-demo.component.ts
+++ b/libs/app/components/playground/playground-demo/playground-demo.component.ts
@@ -4,6 +4,7 @@ import {
   ChangeDetectorRef,
   Component,
   ComponentRef,
+  DestroyRef,
   inject,
   InjectionToken,
   Injector,
@@ -15,6 +16,7 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup } from '@angular/forms';
 import { NgDocDemoDisplayerComponent } from '@ng-doc/app/components/demo-displayer';
 import { formatHtml } from '@ng-doc/app/helpers';
@@ -28,7 +30,6 @@ import { objectKeys } from '@ng-doc/core/helpers/object-keys';
 import { stringify } from '@ng-doc/core/helpers/stringify';
 import { NgDocPlaygroundConfig, NgDocPlaygroundProperties } from '@ng-doc/core/interfaces';
 import { NgDocLetDirective, NgDocSmoothResizeComponent } from '@ng-doc/ui-kit';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Subject } from 'rxjs';
 import { startWith, takeUntil } from 'rxjs/operators';
 
@@ -42,7 +43,6 @@ import { NgDocPlaygroundForm } from '../playground-form';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgDocDemoDisplayerComponent, AsyncPipe, NgDocSmoothResizeComponent, NgDocLetDirective],
 })
-@UntilDestroy()
 export class NgDocPlaygroundDemoComponent<
     T extends NgDocPlaygroundProperties = NgDocPlaygroundProperties,
   >
@@ -81,6 +81,7 @@ export class NgDocPlaygroundDemoComponent<
 
   protected readonly injector = inject(Injector);
   protected readonly changeDetectorRef = inject(ChangeDetectorRef);
+  protected readonly destroyRef = inject(DestroyRef);
 
   private demoRef?: ComponentRef<NgDocBasePlayground>;
   private readonly unsubscribe$: Subject<void> = new Subject<void>();
@@ -104,7 +105,11 @@ export class NgDocPlaygroundDemoComponent<
       await this.updateDemo();
 
       this.form?.valueChanges
-        .pipe(takeUntil(this.unsubscribe$), untilDestroyed(this), startWith(this.form?.value))
+        .pipe(
+          takeUntil(this.unsubscribe$),
+          startWith(this.form?.value),
+          takeUntilDestroyed(this.destroyRef),
+        )
         .subscribe((data: NgDocFormPartialValue<typeof this.form>) => this.updateDemo(data));
     }
   }

--- a/libs/app/components/root/root.component.ts
+++ b/libs/app/components/root/root.component.ts
@@ -10,7 +10,6 @@ import {
 } from '@angular/core';
 import { NgDocSidebarService } from '@ng-doc/app/services';
 import { NgDocContent, NgDocLetDirective, NgDocSidenavComponent } from '@ng-doc/ui-kit';
-import { UntilDestroy } from '@ngneat/until-destroy';
 import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
 
 /**
@@ -59,7 +58,6 @@ export class NgDocCustomSidebarDirective {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgDocLetDirective, NgDocSidenavComponent, NgIf, PolymorpheusModule, AsyncPipe],
 })
-@UntilDestroy()
 export class NgDocRootComponent {
   /**
    * If `true` then the sidebar will be shown

--- a/libs/app/components/search/search.component.ts
+++ b/libs/app/components/search/search.component.ts
@@ -1,5 +1,6 @@
 import { AsyncPipe, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { NgDocSearchEngine } from '@ng-doc/app/classes';
@@ -31,7 +32,6 @@ import {
   observableState,
   StatedObservable,
 } from '@ng-doc/ui-kit';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { BehaviorSubject, NEVER } from 'rxjs';
 import { shareReplay, skip, switchMap } from 'rxjs/operators';
 
@@ -66,7 +66,6 @@ import { shareReplay, skip, switchMap } from 'rxjs/operators';
     NgDocSanitizeHtmlPipe,
   ],
 })
-@UntilDestroy()
 export class NgDocSearchComponent {
   protected readonly query: BehaviorSubject<string> = new BehaviorSubject<string>('');
   protected readonly searchResults: StatedObservable<NgDocSearchResult[]>;
@@ -84,7 +83,7 @@ export class NgDocSearchComponent {
       skip(1),
       switchMap((term: string) => this.searchEngine?.search(term).pipe(observableState()) ?? NEVER),
       shareReplay(1),
-      untilDestroyed(this),
+      takeUntilDestroyed(),
     );
   }
 

--- a/libs/app/components/sidebar/sidebar-category/sidebar-category.component.ts
+++ b/libs/app/components/sidebar/sidebar-category/sidebar-category.component.ts
@@ -18,7 +18,6 @@ import {
   NgDocTextComponent,
   NgDocTextLeftDirective,
 } from '@ng-doc/ui-kit';
-import { UntilDestroy } from '@ngneat/until-destroy';
 import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
 
 @Component({
@@ -39,7 +38,6 @@ import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
     NgTemplateOutlet,
   ],
 })
-@UntilDestroy()
 export class NgDocSidebarCategoryComponent {
   @Input({ required: true })
   category!: NgDocNavigation;

--- a/libs/app/services/sidebar/sidebar.service.ts
+++ b/libs/app/services/sidebar/sidebar.service.ts
@@ -5,7 +5,6 @@ import { NavigationEnd, Router } from '@angular/router';
 import { ngDocZoneOptimize } from '@ng-doc/ui-kit';
 import { NgDocScrollService } from '@ng-doc/ui-kit/services/scroll';
 import { WINDOW } from '@ng-web-apis/common';
-import { UntilDestroy } from '@ngneat/until-destroy';
 import { BehaviorSubject, fromEvent, Observable, share } from 'rxjs';
 import { filter, startWith } from 'rxjs/operators';
 
@@ -15,7 +14,6 @@ import { filter, startWith } from 'rxjs/operators';
 @Injectable({
   providedIn: 'root',
 })
-@UntilDestroy()
 export class NgDocSidebarService {
   protected readonly expanded = new BehaviorSubject<boolean>(false);
   protected readonly document = inject(DOCUMENT);

--- a/libs/app/services/theme/theme.service.ts
+++ b/libs/app/services/theme/theme.service.ts
@@ -2,14 +2,12 @@ import { DOCUMENT } from '@angular/common';
 import { inject, Injectable } from '@angular/core';
 import { NG_DOC_STORE_THEME_KEY } from '@ng-doc/app/constants';
 import { NgDocStoreService } from '@ng-doc/app/services/store';
-import { UntilDestroy } from '@ngneat/until-destroy';
 import { Observable, Subject } from 'rxjs';
 
 /**
  * Service for managing themes.
  */
 @Injectable({ providedIn: 'root' })
-@UntilDestroy()
 export class NgDocThemeService {
   protected readonly document = inject(DOCUMENT);
   protected readonly store = inject(NgDocStoreService);

--- a/libs/builder/helpers/typescript/property/get-defined-in-parent.ts
+++ b/libs/builder/helpers/typescript/property/get-defined-in-parent.ts
@@ -3,35 +3,32 @@ import { Node, SyntaxKind } from 'ts-morph';
 /**
  * Resolves the parent node (TypeReference or TypeAliasDeclaration name)
  * of a property that is defined in a type alias declaration.
- * 
- * Specifically, this resolves type alias declarations that resolve to types 
+ *
+ * Specifically, this resolves type alias declarations that resolve to types
  * that are "object-like", including:
  * - IntersectionTypes,
  * - TypeLiterals, and
  * - TypeReferences (which resolve to IntersectionTypes or TypeLiterals)
- * 
+ *
  * For other types (e.g. UnionType) it just defaults back to the existing
  * rendering.
- *
  * @param property
  * @param currentNode
-
  * @note
  * Similar to `getMemberParent` but handling type aliases declarations
  * rather than member inheritance.
- * 
  * @see libs/builder/helpers/typescript/member/get-member-parent.ts
  */
 export function getDefinedInParent(property: Node, currentNode: Node): Node | undefined {
-  let propertyParent = property.getParent();
+  const propertyParent = property.getParent();
 
-  const excludeCurrentNode = (node: Node | undefined) => node === currentNode ? undefined : node;
+  const excludeCurrentNode = (node: Node | undefined) => (node === currentNode ? undefined : node);
 
-  if(propertyParent?.isKind(SyntaxKind.TypeLiteral)) {
+  if (propertyParent?.isKind(SyntaxKind.TypeLiteral)) {
     return excludeCurrentNode(getDefinedInParent(propertyParent, currentNode) ?? propertyParent);
   }
 
-  if(propertyParent?.isKind(SyntaxKind.IntersectionType)) {
+  if (propertyParent?.isKind(SyntaxKind.IntersectionType)) {
     return excludeCurrentNode(getDefinedInParent(propertyParent, currentNode) ?? propertyParent);
   }
 

--- a/libs/builder/helpers/typescript/property/get-type-alias-properties.ts
+++ b/libs/builder/helpers/typescript/property/get-type-alias-properties.ts
@@ -1,5 +1,5 @@
 import { asArray } from '@ng-doc/core';
-import { TypeAliasDeclaration, PropertySignature, SyntaxKind, TypeNode } from 'ts-morph';
+import { PropertySignature, SyntaxKind, TypeAliasDeclaration, TypeNode } from 'ts-morph';
 
 /**
  * Traverse all of the properties of a type alias declaration,
@@ -10,9 +10,9 @@ import { TypeAliasDeclaration, PropertySignature, SyntaxKind, TypeNode } from 't
  * - IntersectionTypes,
  * - TypeLiterals, and
  * - TypeReferences (which resolve to IntersectionTypes or TypeLiterals)
+ * @param ta
  */
 export function getTypeAliasProperties(ta: TypeAliasDeclaration): PropertySignature[] {
-
   const properties: Map<string, PropertySignature> = new Map<string, PropertySignature>();
 
   const signatures: PropertySignature[] = [];

--- a/libs/builder/helpers/typescript/property/index.ts
+++ b/libs/builder/helpers/typescript/property/index.ts
@@ -1,6 +1,6 @@
 export * from './get-class-properties';
 export * from './get-defined-in-parent';
 export * from './get-interface-properties';
-export * from './get-type-alias-properties';
 export * from './get-property-assignment';
 export * from './get-property-chain';
+export * from './get-type-alias-properties';

--- a/libs/ui-kit/cdk/combobox-host/combobox-host.component.ts
+++ b/libs/ui-kit/cdk/combobox-host/combobox-host.component.ts
@@ -10,6 +10,7 @@ import {
   NgZone,
   ViewChild,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   NgDocBaseInput,
   NgDocDisplayValueHost,
@@ -22,7 +23,6 @@ import { NgDocDropdownHandlerDirective } from '@ng-doc/ui-kit/directives/dropdow
 import { NgDocFocusCatcherDirective } from '@ng-doc/ui-kit/directives/focus-catcher';
 import { ngDocZoneOptimize } from '@ng-doc/ui-kit/observables';
 import { NgDocDisplayValueFunction, NgDocOverlayPosition } from '@ng-doc/ui-kit/types';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import {
   DI_DEFAULT_COMPARE,
   DICompareFunction,
@@ -62,7 +62,6 @@ import { filter } from 'rxjs/operators';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgDocFocusCatcherDirective, NgDocDropdownHandlerDirective],
 })
-@UntilDestroy()
 export class NgDocComboboxHostComponent<T>
   extends DIControl<T>
   implements
@@ -107,8 +106,8 @@ export class NgDocComboboxHostComponent<T>
     this.inputControl?.changes
       .pipe(
         filter(() => !!this.inputControl?.isFocused),
-        untilDestroyed(this),
         ngDocZoneOptimize(this.ngZone),
+        takeUntilDestroyed(this['destroyRef']),
       )
       .subscribe(() => this.dropdown?.open());
   }

--- a/libs/ui-kit/components/clear-control/clear-control.component.ts
+++ b/libs/ui-kit/components/clear-control/clear-control.component.ts
@@ -1,10 +1,10 @@
 import { NgIf } from '@angular/common';
 import { AfterContentInit, ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgDocInputHost } from '@ng-doc/ui-kit/classes/input-host';
 import { NgDocButtonIconComponent } from '@ng-doc/ui-kit/components/button-icon';
 import { NgDocIconComponent } from '@ng-doc/ui-kit/components/icon';
 import { NgDocFocusableDirective } from '@ng-doc/ui-kit/directives/focusable';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { DIControl, injectHostControl } from 'di-controls';
 
 @Component({
@@ -14,7 +14,6 @@ import { DIControl, injectHostControl } from 'di-controls';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIf, NgDocButtonIconComponent, NgDocFocusableDirective, NgDocIconComponent],
 })
-@UntilDestroy()
 export class NgDocClearControlComponent<T> extends DIControl<T> implements AfterContentInit {
   protected readonly inputHost: NgDocInputHost<T> | null = inject(NgDocInputHost, {
     optional: true,
@@ -29,7 +28,7 @@ export class NgDocClearControlComponent<T> extends DIControl<T> implements After
   ngAfterContentInit(): void {
     if (this.inputHost?.inputControl) {
       this.inputHost.inputControl.changes
-        .pipe(untilDestroyed(this))
+        .pipe(takeUntilDestroyed(this['destroyRef']))
         .subscribe(() => this.changeDetectorRef.detectChanges());
     }
   }

--- a/libs/ui-kit/components/dialog-outlet/dialog-outlet.component.ts
+++ b/libs/ui-kit/components/dialog-outlet/dialog-outlet.component.ts
@@ -1,82 +1,83 @@
 import {
-	AfterContentInit,
-	ChangeDetectionStrategy,
-	Component,
-	ContentChild,
-	inject,
-	Input,
-	TemplateRef,
-	ViewChild,
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  Component,
+  ContentChild,
+  DestroyRef,
+  inject,
+  Input,
+  TemplateRef,
+  ViewChild,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
 import { NgDocOverlayRef } from '@ng-doc/ui-kit/classes/overlay-ref';
 import { NgDocDialogConfig, NgDocDialogService } from '@ng-doc/ui-kit/services/dialog';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { merge, NEVER, Subject, switchMap } from 'rxjs';
 import { map, startWith, takeUntil } from 'rxjs/operators';
 
 @Component({
-	selector: 'ng-doc-dialog-outlet',
-	standalone: true,
-	template: `
-		<ng-template #outletContent>
-			<ng-content></ng-content>
-		</ng-template>
-	`,
-	changeDetection: ChangeDetectionStrategy.OnPush,
+  selector: 'ng-doc-dialog-outlet',
+  standalone: true,
+  template: `
+    <ng-template #outletContent>
+      <ng-content></ng-content>
+    </ng-template>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-@UntilDestroy()
 export class DialogOutletComponent implements AfterContentInit {
-	@Input()
-	config?: NgDocDialogConfig;
+  @Input()
+  config?: NgDocDialogConfig;
 
-	@ViewChild('outletContent', { static: true })
-	outletContent!: TemplateRef<never>;
+  @ViewChild('outletContent', { static: true })
+  outletContent!: TemplateRef<never>;
 
-	@ContentChild(RouterOutlet)
-	routerOutlet?: RouterOutlet;
+  @ContentChild(RouterOutlet)
+  routerOutlet?: RouterOutlet;
 
-	dialogRef?: NgDocOverlayRef;
+  dialogRef?: NgDocOverlayRef;
 
-	protected readonly router: Router = inject(Router);
-	protected readonly route: ActivatedRoute = inject(ActivatedRoute);
-	protected readonly dialogService: NgDocDialogService = inject(NgDocDialogService);
+  protected readonly router: Router = inject(Router);
+  protected readonly route: ActivatedRoute = inject(ActivatedRoute);
+  protected readonly dialogService: NgDocDialogService = inject(NgDocDialogService);
+  protected readonly destroyRef = inject(DestroyRef);
 
-	ngAfterContentInit(): void {
-		if (this.routerOutlet) {
-			const dialogRef = new Subject<NgDocOverlayRef>();
+  ngAfterContentInit(): void {
+    if (this.routerOutlet) {
+      const dialogRef = new Subject<NgDocOverlayRef>();
 
-			dialogRef
-				.pipe(
-					switchMap((dialogRef: NgDocOverlayRef) =>
-						dialogRef.beforeClose().pipe(takeUntil(this.routerOutlet?.deactivateEvents ?? NEVER)),
-					),
-					untilDestroyed(this),
-				)
-				.subscribe(() => {
-					const url = this.route.pathFromRoot
-						.map((r) => r.snapshot.url)
-						.filter((f) => !!f[0])
-						.map(([f]) => f.path)
-						.join('/');
+      dialogRef
+        .pipe(
+          switchMap((dialogRef: NgDocOverlayRef) =>
+            dialogRef.beforeClose().pipe(takeUntil(this.routerOutlet?.deactivateEvents ?? NEVER)),
+          ),
+          takeUntilDestroyed(this.destroyRef),
+        )
+        .subscribe(() => {
+          const url = this.route.pathFromRoot
+            .map((r) => r.snapshot.url)
+            .filter((f) => !!f[0])
+            .map(([f]) => f.path)
+            .join('/');
 
-					this.router.navigateByUrl(url);
-				});
+          this.router.navigateByUrl(url);
+        });
 
-			merge(
-				this.routerOutlet.activateEvents.pipe(map(() => true)),
-				this.routerOutlet.deactivateEvents.pipe(map(() => false)),
-			)
-				.pipe(startWith(this.routerOutlet.isActivated), untilDestroyed(this))
-				.subscribe((activated: boolean) => {
-					if (activated) {
-						this.dialogRef = this.dialogService.open(this.outletContent, this.config);
+      merge(
+        this.routerOutlet.activateEvents.pipe(map(() => true)),
+        this.routerOutlet.deactivateEvents.pipe(map(() => false)),
+      )
+        .pipe(startWith(this.routerOutlet.isActivated), takeUntilDestroyed(this.destroyRef))
+        .subscribe((activated: boolean) => {
+          if (activated) {
+            this.dialogRef = this.dialogService.open(this.outletContent, this.config);
 
-						dialogRef.next(this.dialogRef);
-					} else {
-						this.dialogRef?.close();
-					}
-				});
-		}
-	}
+            dialogRef.next(this.dialogRef);
+          } else {
+            this.dialogRef?.close();
+          }
+        });
+    }
+  }
 }

--- a/libs/ui-kit/components/dropdown/dropdown.component.ts
+++ b/libs/ui-kit/components/dropdown/dropdown.component.ts
@@ -1,25 +1,25 @@
 import { Point } from '@angular/cdk/drag-drop';
 import {
-	CdkOverlayOrigin,
-	FlexibleConnectedPositionStrategy,
-	PositionStrategy,
+  CdkOverlayOrigin,
+  FlexibleConnectedPositionStrategy,
+  PositionStrategy,
 } from '@angular/cdk/overlay';
 import {
-	ChangeDetectionStrategy,
-	ChangeDetectorRef,
-	Component,
-	EventEmitter,
-	HostBinding,
-	HostListener,
-	Inject,
-	Input,
-	NgZone,
-	OnChanges,
-	OnDestroy,
-	Optional,
-	Output,
-	SimpleChanges,
-	ViewContainerRef,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  Inject,
+  Input,
+  NgZone,
+  OnChanges,
+  OnDestroy,
+  Optional,
+  Output,
+  SimpleChanges,
+  ViewContainerRef,
 } from '@angular/core';
 import { asArray } from '@ng-doc/core/helpers/as-array';
 import { dropdownOpenAnimation } from '@ng-doc/ui-kit/animations';
@@ -32,256 +32,254 @@ import { ngDocZoneDetach } from '@ng-doc/ui-kit/observables';
 import { NgDocOverlayService } from '@ng-doc/ui-kit/services/overlay';
 import { NgDocContent, NgDocOverlayOrigin, NgDocOverlayPosition } from '@ng-doc/ui-kit/types';
 import { NgDocOverlayUtils } from '@ng-doc/ui-kit/utils';
-import { UntilDestroy } from '@ngneat/until-destroy';
 
 @Component({
-	selector: 'ng-doc-dropdown',
-	template: ``,
-	styleUrls: ['./dropdown.component.scss'],
-	changeDetection: ChangeDetectionStrategy.OnPush,
-	providers: [NgDocOverlayService],
-	standalone: true,
+  selector: 'ng-doc-dropdown',
+  template: ``,
+  styleUrls: ['./dropdown.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [NgDocOverlayService],
+  standalone: true,
 })
-@UntilDestroy()
 export class NgDocDropdownComponent implements OnChanges, OnDestroy {
-	@Input()
-	content: NgDocContent = '';
+  @Input()
+  content: NgDocContent = '';
 
-	@Input()
-	origin: CdkOverlayOrigin | Point | null = null;
+  @Input()
+  origin: CdkOverlayOrigin | Point | null = null;
 
-	@Input()
-	closeIfOutsideClick: boolean = true;
+  @Input()
+  closeIfOutsideClick: boolean = true;
 
-	@Input()
-	closeIfInnerClick: boolean = false;
+  @Input()
+  closeIfInnerClick: boolean = false;
 
-	@Input()
-	withArrow: boolean = false;
+  @Input()
+  withArrow: boolean = false;
 
-	@Input()
-	borderOffset: number = -8;
+  @Input()
+  borderOffset: number = -8;
 
-	@Input()
-	panelClass: string | string[] = [];
+  @Input()
+  panelClass: string | string[] = [];
 
-	@Input()
-	contactBorder: boolean = true;
+  @Input()
+  contactBorder: boolean = true;
 
-	@Input()
-	hasBackdrop: boolean = false;
+  @Input()
+  hasBackdrop: boolean = false;
 
-	@Input()
-	positions: NgDocOverlayPosition | NgDocOverlayPosition[] = [
-		'bottom-center',
-		'top-center',
-		'right-center',
-		'left-center',
-	];
+  @Input()
+  positions: NgDocOverlayPosition | NgDocOverlayPosition[] = [
+    'bottom-center',
+    'top-center',
+    'right-center',
+    'left-center',
+  ];
 
-	@Input()
-	minHeight: number | string = '';
+  @Input()
+  minHeight: number | string = '';
 
-	@Input()
-	maxHeight: number | string = '';
+  @Input()
+  maxHeight: number | string = '';
 
-	@Input()
-	height: number | string = '';
+  @Input()
+  height: number | string = '';
 
-	@Input()
-	minWidth: number | string = '';
+  @Input()
+  minWidth: number | string = '';
 
-	@Input()
-	maxWidth: number | string = '';
+  @Input()
+  maxWidth: number | string = '';
 
-	@Input()
-	width: number | string = '';
+  @Input()
+  width: number | string = '';
 
-	@Output()
-	beforeOpen: EventEmitter<void> = new EventEmitter<void>();
+  @Output()
+  beforeOpen: EventEmitter<void> = new EventEmitter<void>();
 
-	@Output()
-	afterOpen: EventEmitter<void> = new EventEmitter<void>();
+  @Output()
+  afterOpen: EventEmitter<void> = new EventEmitter<void>();
 
-	@Output()
-	beforeClose: EventEmitter<void> = new EventEmitter<void>();
+  @Output()
+  beforeClose: EventEmitter<void> = new EventEmitter<void>();
 
-	@Output()
-	afterClose: EventEmitter<void> = new EventEmitter<void>();
+  @Output()
+  afterClose: EventEmitter<void> = new EventEmitter<void>();
 
-	overlay: NgDocOverlayRef | null = null;
-	overlayProperties: NgDocOverlayProperties = this.getOverlayProperties();
+  overlay: NgDocOverlayRef | null = null;
+  overlayProperties: NgDocOverlayProperties = this.getOverlayProperties();
 
-	constructor(
-		protected changeDetectorRef: ChangeDetectorRef,
-		protected overlayService: NgDocOverlayService,
-		protected viewContainerRef: ViewContainerRef,
-		protected ngZone: NgZone,
-		@Inject(NgDocOverlayHost)
-		@Optional()
-		protected overlayHost?: NgDocOverlayHost,
-	) {}
+  constructor(
+    protected changeDetectorRef: ChangeDetectorRef,
+    protected overlayService: NgDocOverlayService,
+    protected viewContainerRef: ViewContainerRef,
+    protected ngZone: NgZone,
+    @Inject(NgDocOverlayHost)
+    @Optional()
+    protected overlayHost?: NgDocOverlayHost,
+  ) {}
 
-	ngOnChanges({ origin }: SimpleChanges): void {
-		if (origin && origin.currentValue !== origin.previousValue) {
-			if (!origin.currentValue) {
-				this.origin = origin.previousValue as CdkOverlayOrigin | Point | null;
-			}
+  ngOnChanges({ origin }: SimpleChanges): void {
+    if (origin && origin.currentValue !== origin.previousValue) {
+      if (!origin.currentValue) {
+        this.origin = origin.previousValue as CdkOverlayOrigin | Point | null;
+      }
 
-			if (this.overlay) {
-				const positionStrategy: PositionStrategy | undefined =
-					this.overlay.overlayRef.getConfig().positionStrategy;
-				if (positionStrategy instanceof FlexibleConnectedPositionStrategy && this.currentOrigin) {
-					this.overlay.overlayRef.updatePositionStrategy(
-						positionStrategy.setOrigin(this.currentOrigin),
-					);
-				}
-			}
-		}
-		this.updateOverlayPosition();
-	}
+      if (this.overlay) {
+        const positionStrategy: PositionStrategy | undefined =
+          this.overlay.overlayRef.getConfig().positionStrategy;
+        if (positionStrategy instanceof FlexibleConnectedPositionStrategy && this.currentOrigin) {
+          this.overlay.overlayRef.updatePositionStrategy(
+            positionStrategy.setOrigin(this.currentOrigin),
+          );
+        }
+      }
+    }
+    this.updateOverlayPosition();
+  }
 
-	@HostBinding('attr.tabIndex')
-	get tabIndex(): number {
-		return this.isOpened ? 0 : -1;
-	}
+  @HostBinding('attr.tabIndex')
+  get tabIndex(): number {
+    return this.isOpened ? 0 : -1;
+  }
 
-	@HostListener('focus')
-	focus(): void {
-		this.overlay?.focus();
-	}
+  @HostListener('focus')
+  focus(): void {
+    this.overlay?.focus();
+  }
 
-	get isFocused(): boolean {
-		return !!this.overlay?.isFocused;
-	}
+  get isFocused(): boolean {
+    return !!this.overlay?.isFocused;
+  }
 
-	open(): void {
-		if (!this.overlay?.hasAttached) {
-			const config: NgDocOverlayConfig = this.getConfig();
-			this.overlay = this.overlayService.open(this.content, config);
-			this.beforeOpen.emit();
-			this.overlay
-				?.afterOpen()
-				.pipe(ngDocZoneDetach(this.ngZone))
-				.subscribe(() => this.afterOpen.emit());
+  open(): void {
+    if (!this.overlay?.hasAttached) {
+      const config: NgDocOverlayConfig = this.getConfig();
+      this.overlay = this.overlayService.open(this.content, config);
+      this.beforeOpen.emit();
+      this.overlay
+        ?.afterOpen()
+        .pipe(ngDocZoneDetach(this.ngZone))
+        .subscribe(() => this.afterOpen.emit());
 
-			this.overlay
-				?.beforeClose()
-				.pipe(ngDocZoneDetach(this.ngZone))
-				.subscribe(() => this.beforeClose.emit());
+      this.overlay
+        ?.beforeClose()
+        .pipe(ngDocZoneDetach(this.ngZone))
+        .subscribe(() => this.beforeClose.emit());
 
-			this.overlay
-				?.afterClose()
-				.pipe(ngDocZoneDetach(this.ngZone))
-				.subscribe(() => this.afterClose.emit());
+      this.overlay
+        ?.afterClose()
+        .pipe(ngDocZoneDetach(this.ngZone))
+        .subscribe(() => this.afterClose.emit());
 
-			this.overlay.beforeClose().subscribe(() => this.close());
+      this.overlay.beforeClose().subscribe(() => this.close());
 
-			this.changeDetectorRef.markForCheck();
-		}
-	}
+      this.changeDetectorRef.markForCheck();
+    }
+  }
 
-	close(): void {
-		if (this.isOpened) {
-			this.overlay?.close();
-			this.changeDetectorRef.markForCheck();
-		}
-	}
+  close(): void {
+    if (this.isOpened) {
+      this.overlay?.close();
+      this.changeDetectorRef.markForCheck();
+    }
+  }
 
-	toggle(): void {
-		this.isOpened ? this.close() : this.open();
-	}
+  toggle(): void {
+    this.isOpened ? this.close() : this.open();
+  }
 
-	get isOpened(): boolean {
-		return this.overlay?.isOpened === true;
-	}
+  get isOpened(): boolean {
+    return this.overlay?.isOpened === true;
+  }
 
-	updateOverlayPosition(): void {
-		if (this.overlay && this.overlay.hasAttached) {
-			this.overlay.overlayRef.updateSize(this.getConfig());
-			this.overlay.overlayRef.updatePosition();
-		}
-	}
+  updateOverlayPosition(): void {
+    if (this.overlay && this.overlay.hasAttached) {
+      this.overlay.overlayRef.updateSize(this.getConfig());
+      this.overlay.overlayRef.updatePosition();
+    }
+  }
 
-	private get currentOrigin(): NgDocOverlayOrigin | null {
-		return this.origin instanceof CdkOverlayOrigin
-			? (this.origin.elementRef.nativeElement as HTMLElement)
-			: this.origin || this.overlayHost?.origin || null;
-	}
+  private get currentOrigin(): NgDocOverlayOrigin | null {
+    return this.origin instanceof CdkOverlayOrigin
+      ? (this.origin.elementRef.nativeElement as HTMLElement)
+      : this.origin || this.overlayHost?.origin || null;
+  }
 
-	private getPositions(
-		positions: NgDocOverlayPosition | NgDocOverlayPosition[],
-		border: number,
-	): NgDocOverlayPosition[] {
-		const origin: NgDocOverlayOrigin = toElement(this.currentOrigin) as HTMLElement;
-		if (origin instanceof HTMLElement) {
-			return NgDocOverlayUtils.getConnectedPosition(
-				!!positions && asArray(positions).length
-					? positions
-					: ['bottom-center', 'top-center', 'right-center', 'left-center'],
-				origin,
-				border * -1,
-				this.withArrow,
-			);
-		} else {
-			return !!positions && asArray(positions).length
-				? asArray(positions)
-				: ['bottom-center', 'top-center', 'right-center', 'left-center'];
-		}
-	}
+  private getPositions(
+    positions: NgDocOverlayPosition | NgDocOverlayPosition[],
+    border: number,
+  ): NgDocOverlayPosition[] {
+    const origin: NgDocOverlayOrigin = toElement(this.currentOrigin) as HTMLElement;
+    if (origin instanceof HTMLElement) {
+      return NgDocOverlayUtils.getConnectedPosition(
+        !!positions && asArray(positions).length
+          ? positions
+          : ['bottom-center', 'top-center', 'right-center', 'left-center'],
+        origin,
+        border * -1,
+        this.withArrow,
+      );
+    } else {
+      return !!positions && asArray(positions).length
+        ? asArray(positions)
+        : ['bottom-center', 'top-center', 'right-center', 'left-center'];
+    }
+  }
 
-	private getConfig(): NgDocOverlayConfig {
-		const overlayProperties: NgDocOverlayProperties = mergeOverlayConfigs(
-			this.overlayProperties,
-			this.getOverlayProperties(),
-			this.overlayHost,
-		);
-		if (!this.currentOrigin) {
-			throw new Error('Origin for the dropdown was not provided.');
-		}
-		return {
-			overlayContainer: NgDocOverlayContainerComponent,
-			positionStrategy: this.overlayService.connectedPositionStrategy(
-				this.currentOrigin,
-				this.getPositions(overlayProperties.positions || [], overlayProperties.borderOffset || 0),
-			),
-			scrollStrategy: this.overlayService.scrollStrategy().reposition(),
-			viewContainerRef: this.viewContainerRef,
-			openAnimation: dropdownOpenAnimation,
-			hasBackdrop: this.hasBackdrop,
-			...overlayProperties,
-			panelClass: [
-				'ng-doc-dropdown',
-				...asArray(this.panelClass),
-				...asArray(this.overlayHost?.panelClass),
-			],
-		};
-	}
+  private getConfig(): NgDocOverlayConfig {
+    const overlayProperties: NgDocOverlayProperties = mergeOverlayConfigs(
+      this.overlayProperties,
+      this.getOverlayProperties(),
+      this.overlayHost,
+    );
+    if (!this.currentOrigin) {
+      throw new Error('Origin for the dropdown was not provided.');
+    }
+    return {
+      overlayContainer: NgDocOverlayContainerComponent,
+      positionStrategy: this.overlayService.connectedPositionStrategy(
+        this.currentOrigin,
+        this.getPositions(overlayProperties.positions || [], overlayProperties.borderOffset || 0),
+      ),
+      scrollStrategy: this.overlayService.scrollStrategy().reposition(),
+      viewContainerRef: this.viewContainerRef,
+      openAnimation: dropdownOpenAnimation,
+      hasBackdrop: this.hasBackdrop,
+      ...overlayProperties,
+      panelClass: [
+        'ng-doc-dropdown',
+        ...asArray(this.panelClass),
+        ...asArray(this.overlayHost?.panelClass),
+      ],
+    };
+  }
 
-	private getOverlayProperties(): NgDocOverlayProperties {
-		return {
-			origin: this.currentOrigin || undefined,
-			positions: this.positions,
-			closeIfOutsideClick: this.closeIfOutsideClick,
-			closeIfInnerClick: this.closeIfInnerClick,
-			withPointer: this.withArrow,
-			contactBorder: this.contactBorder,
-			borderOffset: this.borderOffset,
-			panelClass: this.panelClass,
-			width: this.width,
-			height: this.height,
-			minWidth: this.minWidth,
-			minHeight: this.minHeight,
-			maxWidth: this.maxWidth,
-			maxHeight: this.maxHeight,
-			disposeOnNavigation: true,
-			disposeOnRouteNavigation: true,
-		};
-	}
+  private getOverlayProperties(): NgDocOverlayProperties {
+    return {
+      origin: this.currentOrigin || undefined,
+      positions: this.positions,
+      closeIfOutsideClick: this.closeIfOutsideClick,
+      closeIfInnerClick: this.closeIfInnerClick,
+      withPointer: this.withArrow,
+      contactBorder: this.contactBorder,
+      borderOffset: this.borderOffset,
+      panelClass: this.panelClass,
+      width: this.width,
+      height: this.height,
+      minWidth: this.minWidth,
+      minHeight: this.minHeight,
+      maxWidth: this.maxWidth,
+      maxHeight: this.maxHeight,
+      disposeOnNavigation: true,
+      disposeOnRouteNavigation: true,
+    };
+  }
 
-	ngOnDestroy(): void {
-		if (this.overlay) {
-			this.overlay.overlayRef.dispose();
-		}
-	}
+  ngOnDestroy(): void {
+    if (this.overlay) {
+      this.overlay.overlayRef.dispose();
+    }
+  }
 }

--- a/libs/ui-kit/components/input-wrapper/input-wrapper.component.ts
+++ b/libs/ui-kit/components/input-wrapper/input-wrapper.component.ts
@@ -19,7 +19,6 @@ import { ngDocMakePure } from '@ng-doc/ui-kit/decorators';
 import { NgDocFocusCatcherDirective } from '@ng-doc/ui-kit/directives/focus-catcher';
 import { NgDocContextWithImplicit } from '@ng-doc/ui-kit/interfaces';
 import { NgDocContent, NgDocTextAlign } from '@ng-doc/ui-kit/types';
-import { UntilDestroy } from '@ngneat/until-destroy';
 import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
 
 @Component({
@@ -42,7 +41,6 @@ import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
     NgDocFloatedContentComponent,
   ],
 })
-@UntilDestroy()
 export class NgDocInputWrapperComponent<T, B = unknown>
   implements AfterViewChecked, NgDocInputHost<T>
 {

--- a/libs/ui-kit/components/list/list.component.ts
+++ b/libs/ui-kit/components/list/list.component.ts
@@ -1,84 +1,83 @@
 import { ListKeyManager } from '@angular/cdk/a11y';
 import {
-	ChangeDetectionStrategy,
-	Component,
-	ElementRef,
-	Inject,
-	NgZone,
-	Optional,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Inject,
+  NgZone,
+  Optional,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { asArray } from '@ng-doc/core/helpers/as-array';
 import { NgDocListHost } from '@ng-doc/ui-kit/classes/list-host';
 import { NgDocListItem } from '@ng-doc/ui-kit/classes/list-item';
 import { toElement } from '@ng-doc/ui-kit/helpers';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { fromEvent, merge, NEVER } from 'rxjs';
 import { delayWhen, filter, repeat, takeUntil } from 'rxjs/operators';
 
 @Component({
-	selector: 'ng-doc-list',
-	templateUrl: './list.component.html',
-	styleUrls: ['./list.component.scss'],
-	changeDetection: ChangeDetectionStrategy.OnPush,
-	standalone: true,
+  selector: 'ng-doc-list',
+  templateUrl: './list.component.html',
+  styleUrls: ['./list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
 })
-@UntilDestroy()
 export class NgDocListComponent {
-	private keyManager: ListKeyManager<NgDocListItem> | null = null;
-	private readonly items: Set<NgDocListItem> = new Set<NgDocListItem>();
+  private keyManager: ListKeyManager<NgDocListItem> | null = null;
+  private readonly items: Set<NgDocListItem> = new Set<NgDocListItem>();
 
-	constructor(
-		private elementRef: ElementRef<HTMLElement>,
-		private ngZone: NgZone,
-		@Inject(NgDocListHost) @Optional() private listHost?: NgDocListHost,
-	) {
-		const origin: HTMLElement | null = this.listHost?.listHostOrigin
-			? toElement(this.listHost?.listHostOrigin)
-			: null;
-		const list: HTMLElement = toElement(this.elementRef);
+  constructor(
+    private elementRef: ElementRef<HTMLElement>,
+    private ngZone: NgZone,
+    @Inject(NgDocListHost) @Optional() private listHost?: NgDocListHost,
+  ) {
+    const origin: HTMLElement | null = this.listHost?.listHostOrigin
+      ? toElement(this.listHost?.listHostOrigin)
+      : null;
+    const list: HTMLElement = toElement(this.elementRef);
 
-		merge(
-			fromEvent(list, 'keydown'),
-			origin
-				? fromEvent(origin, 'keydown').pipe(
-						takeUntil(fromEvent(list, 'keydown')),
-						delayWhen(() => this.ngZone.onStable),
-						repeat(),
-				  )
-				: NEVER,
-		)
-			.pipe(
-				filter((event: Event) => !event.defaultPrevented),
-				untilDestroyed(this),
-			)
-			.subscribe((event: Event) => {
-				const typedEvent: KeyboardEvent = event as KeyboardEvent;
+    merge(
+      fromEvent(list, 'keydown'),
+      origin
+        ? fromEvent(origin, 'keydown').pipe(
+            takeUntil(fromEvent(list, 'keydown')),
+            delayWhen(() => this.ngZone.onStable),
+            repeat(),
+          )
+        : NEVER,
+    )
+      .pipe(
+        filter((event: Event) => !event.defaultPrevented),
+        takeUntilDestroyed(),
+      )
+      .subscribe((event: Event) => {
+        const typedEvent: KeyboardEvent = event as KeyboardEvent;
 
-				switch (typedEvent.key) {
-					case 'Enter':
-						this.keyManager?.activeItem?.selectByUser();
+        switch (typedEvent.key) {
+          case 'Enter':
+            this.keyManager?.activeItem?.selectByUser();
 
-						typedEvent.preventDefault();
-						break;
-				}
+            typedEvent.preventDefault();
+            break;
+        }
 
-				this.keyManager?.activeItem?.setInactiveStyles();
-				this.keyManager?.onKeydown(typedEvent);
-				this.keyManager?.activeItem?.setActiveStyles();
+        this.keyManager?.activeItem?.setInactiveStyles();
+        this.keyManager?.onKeydown(typedEvent);
+        this.keyManager?.activeItem?.setActiveStyles();
 
-				if (this.keyManager?.activeItem)
-					toElement(this.keyManager?.activeItem.elementRef).scrollIntoView({ block: 'nearest' });
-			});
-	}
+        if (this.keyManager?.activeItem)
+          toElement(this.keyManager?.activeItem.elementRef).scrollIntoView({ block: 'nearest' });
+      });
+  }
 
-	registerItem(item: NgDocListItem): void {
-		this.items.add(item);
+  registerItem(item: NgDocListItem): void {
+    this.items.add(item);
 
-		this.keyManager?.activeItem?.setInactiveStyles();
-		this.keyManager = new ListKeyManager(asArray(this.items)).withVerticalOrientation(true);
-	}
+    this.keyManager?.activeItem?.setInactiveStyles();
+    this.keyManager = new ListKeyManager(asArray(this.items)).withVerticalOrientation(true);
+  }
 
-	unregisterItem(item: NgDocListItem): void {
-		this.items.delete(item);
-	}
+  unregisterItem(item: NgDocListItem): void {
+    this.items.delete(item);
+  }
 }

--- a/libs/ui-kit/components/option-group/option-group.component.ts
+++ b/libs/ui-kit/components/option-group/option-group.component.ts
@@ -5,12 +5,14 @@ import {
   ChangeDetectorRef,
   Component,
   ContentChildren,
+  DestroyRef,
   Directive,
+  inject,
   QueryList,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgDocOptionComponent } from '@ng-doc/ui-kit/components/option';
 import { NgDocTextComponent } from '@ng-doc/ui-kit/components/text';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { startWith } from 'rxjs/operators';
 
 @Directive({
@@ -26,17 +28,18 @@ export class NgDocOptionGroupHeaderDirective {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgIf, NgDocTextComponent],
 })
-@UntilDestroy()
 export class NgDocOptionGroupComponent<T> implements AfterContentInit {
   @ContentChildren(NgDocOptionComponent, { descendants: true })
   options: QueryList<NgDocOptionComponent<T>> = new QueryList<NgDocOptionComponent<T>>();
   hasHeader: boolean = false;
 
+  private readonly destroyRef = inject(DestroyRef);
+
   constructor(private changeDetectorRef: ChangeDetectorRef) {}
 
   ngAfterContentInit(): void {
     this.options.changes
-      .pipe(startWith(this.options), untilDestroyed(this))
+      .pipe(startWith(this.options), takeUntilDestroyed(this.destroyRef))
       .subscribe((options: QueryList<NgDocOptionComponent<T>>) => {
         this.hasHeader = !!options.length;
         this.changeDetectorRef.markForCheck();

--- a/libs/ui-kit/components/pane/pane.component.ts
+++ b/libs/ui-kit/components/pane/pane.component.ts
@@ -1,155 +1,158 @@
 import { DOCUMENT } from '@angular/common';
 import {
-	afterNextRender,
-	ChangeDetectionStrategy,
-	ChangeDetectorRef,
-	Component,
-	Directive,
-	ElementRef,
-	HostBinding,
-	Inject,
-	Input,
-	NgZone,
-	OnChanges,
-	SimpleChanges,
-	ViewChild,
+  afterNextRender,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  Directive,
+  ElementRef,
+  HostBinding,
+  Inject,
+  inject,
+  Input,
+  NgZone,
+  OnChanges,
+  SimpleChanges,
+  ViewChild,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ngDocZoneOptimize } from '@ng-doc/ui-kit/observables';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { fromEvent, merge, Observable } from 'rxjs';
 import {
-	debounceTime,
-	filter,
-	map,
-	pairwise,
-	switchMap,
-	take,
-	takeUntil,
-	tap,
+  debounceTime,
+  filter,
+  map,
+  pairwise,
+  switchMap,
+  take,
+  takeUntil,
+  tap,
 } from 'rxjs/operators';
 
 @Directive({
-	selector: '[ngDocPaneFront]',
-	standalone: true,
+  selector: '[ngDocPaneFront]',
+  standalone: true,
 })
 export class NgDocPaneFrontDirective {}
 
 @Directive({
-	selector: '[ngDocPaneBack]',
-	standalone: true,
+  selector: '[ngDocPaneBack]',
+  standalone: true,
 })
 export class NgDocPaneBackDirective {}
 
 @Component({
-	selector: 'ng-doc-pane',
-	templateUrl: './pane.component.html',
-	styleUrls: ['./pane.component.scss'],
-	changeDetection: ChangeDetectionStrategy.OnPush,
-	standalone: true,
+  selector: 'ng-doc-pane',
+  templateUrl: './pane.component.html',
+  styleUrls: ['./pane.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
 })
-@UntilDestroy()
 export class NgDocPaneComponent implements OnChanges {
-	@Input()
-	expanded: boolean = false;
+  @Input()
+  expanded: boolean = false;
 
-	@ViewChild('resizer', { static: true })
-	resizer?: ElementRef<HTMLElement>;
+  @ViewChild('resizer', { static: true })
+  resizer?: ElementRef<HTMLElement>;
 
-	width: string = '0%';
+  width: string = '0%';
 
-	@HostBinding('attr.data-ng-doc-dragging')
-	dragging: boolean = false;
+  @HostBinding('attr.data-ng-doc-dragging')
+  dragging: boolean = false;
 
-	constructor(
-		@Inject(DOCUMENT)
-		private readonly document: Document,
-		private readonly changeDetectorRef: ChangeDetectorRef,
-		private readonly elementRef: ElementRef<HTMLElement>,
-		private readonly ngZone: NgZone,
-	) {
-		afterNextRender(() => {
-			if (this.resizer) {
-				const mouseDown$ = fromEvent(this.resizer.nativeElement, 'mousedown').pipe(
-					tap(() => {
-						this.dragging = true;
-						this.changeDetectorRef.markForCheck();
-					}),
-				);
+  constructor(
+    @Inject(DOCUMENT)
+    private readonly document: Document,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly elementRef: ElementRef<HTMLElement>,
+    private readonly ngZone: NgZone,
+  ) {
+    const destroyRef = inject(DestroyRef);
 
-				const mouseUp$ = fromEvent(this.document, 'mouseup').pipe(
-					tap(() => {
-						this.dragging = false;
-						this.changeDetectorRef.markForCheck();
-					}),
-				);
+    afterNextRender(() => {
+      if (this.resizer) {
+        const mouseDown$ = fromEvent(this.resizer.nativeElement, 'mousedown').pipe(
+          tap(() => {
+            this.dragging = true;
+            this.changeDetectorRef.markForCheck();
+          }),
+        );
 
-				const mouseMove$ = (fromEvent(this.document, 'mousemove') as Observable<MouseEvent>).pipe(
-					map((event: MouseEvent) => event.clientX),
-					pairwise(),
-					map(([prev, next]: [number, number]) => next - prev),
-				);
+        const mouseUp$ = fromEvent(this.document, 'mouseup').pipe(
+          tap(() => {
+            this.dragging = false;
+            this.changeDetectorRef.markForCheck();
+          }),
+        );
 
-				mouseDown$
-					.pipe(
-						switchMap(() => {
-							const dragEvent$ = mouseMove$.pipe(takeUntil(mouseUp$));
+        const mouseMove$ = (fromEvent(this.document, 'mousemove') as Observable<MouseEvent>).pipe(
+          map((event: MouseEvent) => event.clientX),
+          pairwise(),
+          map(([prev, next]: [number, number]) => next - prev),
+        );
 
-							const clickEvent$ = mouseUp$.pipe(
-								map(() => null),
-								takeUntil(mouseMove$),
-								take(1),
-							);
+        mouseDown$
+          .pipe(
+            switchMap(() => {
+              const dragEvent$ = mouseMove$.pipe(takeUntil(mouseUp$));
 
-							return merge(dragEvent$, clickEvent$);
-						}),
-						filter((delta: number | null) => delta !== 0),
-						ngDocZoneOptimize(this.ngZone),
-						untilDestroyed(this),
-					)
-					.subscribe((delta: number | null) => {
-						delta === null ? this.toggle() : this.addDelta(delta);
-					});
-			}
+              const clickEvent$ = mouseUp$.pipe(
+                map(() => null),
+                takeUntil(mouseMove$),
+                take(1),
+              );
 
-			fromEvent(window, 'resize')
-				.pipe(debounceTime(100), untilDestroyed(this), ngDocZoneOptimize(this.ngZone))
-				.subscribe(() => this.addDelta(0));
-		});
+              return merge(dragEvent$, clickEvent$);
+            }),
+            filter((delta: number | null) => delta !== 0),
+            ngDocZoneOptimize(this.ngZone),
+            takeUntilDestroyed(destroyRef),
+          )
+          .subscribe((delta: number | null) => {
+            delta === null ? this.toggle() : this.addDelta(delta);
+          });
+      }
 
-		this.addDelta(0);
-	}
+      fromEvent(window, 'resize')
+        .pipe(debounceTime(100), ngDocZoneOptimize(this.ngZone), takeUntilDestroyed(destroyRef))
+        .subscribe(() => this.addDelta(0));
+    });
 
-	ngOnChanges({ expanded }: SimpleChanges): void {
-		if (expanded) {
-			expanded.currentValue
-				? this.addDelta(this.elementRef.nativeElement.offsetWidth)
-				: this.addDelta(-this.elementRef.nativeElement.offsetWidth);
-		}
-	}
+    this.addDelta(0);
+  }
 
-	toggle(): void {
-		if (this.resizer) {
-			const middle = this.elementRef.nativeElement.offsetWidth / 2;
+  ngOnChanges({ expanded }: SimpleChanges): void {
+    if (expanded) {
+      expanded.currentValue
+        ? this.addDelta(this.elementRef.nativeElement.offsetWidth)
+        : this.addDelta(-this.elementRef.nativeElement.offsetWidth);
+    }
+  }
 
-			if (this.resizer.nativeElement.offsetLeft < middle) {
-				this.addDelta(this.elementRef.nativeElement.offsetWidth);
-			} else {
-				this.addDelta(-this.elementRef.nativeElement.offsetWidth);
-			}
-		}
-	}
+  toggle(): void {
+    if (this.resizer) {
+      const middle = this.elementRef.nativeElement.offsetWidth / 2;
 
-	private addDelta(delta: number): void {
-		if (this.resizer) {
-			const maxWidth =
-				this.elementRef.nativeElement.offsetWidth - this.resizer.nativeElement.offsetWidth;
+      if (this.resizer.nativeElement.offsetLeft < middle) {
+        this.addDelta(this.elementRef.nativeElement.offsetWidth);
+      } else {
+        this.addDelta(-this.elementRef.nativeElement.offsetWidth);
+      }
+    }
+  }
 
-			this.width = `${Math.min(
-				maxWidth,
-				Math.max(0, this.resizer.nativeElement.offsetLeft + delta),
-			)}px`;
+  private addDelta(delta: number): void {
+    if (this.resizer) {
+      const maxWidth =
+        this.elementRef.nativeElement.offsetWidth - this.resizer.nativeElement.offsetWidth;
 
-			this.changeDetectorRef.detectChanges();
-		}
-	}
+      this.width = `${Math.min(
+        maxWidth,
+        Math.max(0, this.resizer.nativeElement.offsetLeft + delta),
+      )}px`;
+
+      this.changeDetectorRef.detectChanges();
+    }
+  }
 }

--- a/libs/ui-kit/components/selection/selection.component.ts
+++ b/libs/ui-kit/components/selection/selection.component.ts
@@ -2,12 +2,14 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   ElementRef,
   HostBinding,
+  inject,
   Input,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgDocHorizontalAlign, NgDocPosition, NgDocVerticalAlign } from '@ng-doc/ui-kit/types';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { debounceTime } from 'rxjs/operators';
 
 import { NgDocSelectionHostDirective } from './selection-host.directive';
@@ -19,11 +21,12 @@ import { NgDocSelectionHostDirective } from './selection-host.directive';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
 })
-@UntilDestroy()
 export class NgDocSelectionComponent implements AfterViewInit {
   @Input()
   @HostBinding('attr.data-ng-doc-align')
   align: NgDocHorizontalAlign | NgDocVerticalAlign = 'bottom';
+
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private readonly elementRef: ElementRef<HTMLElement>,
@@ -32,7 +35,7 @@ export class NgDocSelectionComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     this.selectionHost.selectedChange$
-      .pipe(debounceTime(0), untilDestroyed(this))
+      .pipe(debounceTime(0), takeUntilDestroyed(this.destroyRef))
       .subscribe((selected: HTMLElement | undefined) => this.setStyles(selected));
   }
 

--- a/libs/ui-kit/components/toggle/toggle.component.ts
+++ b/libs/ui-kit/components/toggle/toggle.component.ts
@@ -1,147 +1,146 @@
 import {
-	ChangeDetectionStrategy,
-	Component,
-	ElementRef,
-	HostBinding,
-	inject,
-	OnInit,
-	ViewChild,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostBinding,
+  inject,
+  OnInit,
+  ViewChild,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor } from '@angular/forms';
 import { NgDocPositionUtils } from '@ng-doc/ui-kit/utils';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { DICompareHost, DIStateControl, injectHostControl } from 'di-controls';
 import { fromEvent } from 'rxjs';
 import { filter, last, map, pairwise, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
 
 @Component({
-	selector: 'ng-doc-toggle',
-	templateUrl: './toggle.component.html',
-	styleUrls: ['./toggle.component.scss'],
-	changeDetection: ChangeDetectionStrategy.OnPush,
-	standalone: true,
+  selector: 'ng-doc-toggle',
+  templateUrl: './toggle.component.html',
+  styleUrls: ['./toggle.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
 })
-@UntilDestroy()
 export class NgDocToggleComponent<T>
-	extends DIStateControl<T>
-	implements OnInit, ControlValueAccessor
+  extends DIStateControl<T>
+  implements OnInit, ControlValueAccessor
 {
-	@ViewChild('wrapper', { static: true })
-	private wrapper?: ElementRef<HTMLElement>;
+  @ViewChild('wrapper', { static: true })
+  private wrapper?: ElementRef<HTMLElement>;
 
-	@ViewChild('circle', { static: true })
-	private circle?: ElementRef<HTMLElement>;
+  @ViewChild('circle', { static: true })
+  private circle?: ElementRef<HTMLElement>;
 
-	@HostBinding('attr.data-ng-doc-dragging')
-	dragging: boolean = false;
+  @HostBinding('attr.data-ng-doc-dragging')
+  dragging: boolean = false;
 
-	private maxPixelValue: number = 0;
+  private maxPixelValue: number = 0;
 
-	constructor() {
-		super({
-			host: injectHostControl({ optional: true }),
-			compareHost: inject(DICompareHost, { optional: true }),
-			onIncomingUpdate: () => {
-				this.setState(!!this.checked());
-			},
-		});
-	}
+  constructor() {
+    super({
+      host: injectHostControl({ optional: true }),
+      compareHost: inject(DICompareHost, { optional: true }),
+      onIncomingUpdate: () => {
+        this.setState(!!this.checked());
+      },
+    });
+  }
 
-	override ngOnInit(): void {
-		super.ngOnInit();
-		if (this.wrapper && this.circle) {
-			this.maxPixelValue =
-				this.wrapper.nativeElement.offsetWidth - this.circle.nativeElement.offsetWidth - 6;
-			fromEvent(this.circle.nativeElement, 'mousedown')
-				.pipe(
-					filter(() => !this.disabled),
-					switchMap(() => {
-						const transition: string = this.circle?.nativeElement.style.transition ?? '';
-						this.renderer.setStyle(this.circle?.nativeElement, 'transition', '');
-						this.setDragging(true);
+  override ngOnInit(): void {
+    super.ngOnInit();
+    if (this.wrapper && this.circle) {
+      this.maxPixelValue =
+        this.wrapper.nativeElement.offsetWidth - this.circle.nativeElement.offsetWidth - 6;
+      fromEvent(this.circle.nativeElement, 'mousedown')
+        .pipe(
+          filter(() => !this.disabled),
+          switchMap(() => {
+            const transition: string = this.circle?.nativeElement.style.transition ?? '';
+            this.renderer.setStyle(this.circle?.nativeElement, 'transition', '');
+            this.setDragging(true);
 
-						return fromEvent(document.body, 'mousemove').pipe(
-							pairwise(),
-							map(
-								([newEvent, oldEvent]: [Event, Event]) =>
-									[newEvent, oldEvent] as [MouseEvent, MouseEvent],
-							),
-							map(
-								([newEvent, oldEvent]: [MouseEvent, MouseEvent]) =>
-									oldEvent.clientX - newEvent.clientX,
-							),
-							filter((deltaX: number) => deltaX !== 0),
-							tap((deltaX: number) => this.changeCirclePosition(deltaX)),
-							startWith(null),
-							takeUntil(
-								fromEvent(document.body, 'mouseup').pipe(tap(() => this.setDragging(false))),
-							),
-							last(),
-							tap(
-								() =>
-									this.circle &&
-									this.renderer.setStyle(this.circle.nativeElement, 'transition', transition),
-							),
-						);
-					}),
-					untilDestroyed(this),
-				)
-				.subscribe((deltaX: number | null) => {
-					deltaX === null ? this.toggle() : this.detectByCoordinates();
-				});
-		}
-	}
+            return fromEvent(document.body, 'mousemove').pipe(
+              pairwise(),
+              map(
+                ([newEvent, oldEvent]: [Event, Event]) =>
+                  [newEvent, oldEvent] as [MouseEvent, MouseEvent],
+              ),
+              map(
+                ([newEvent, oldEvent]: [MouseEvent, MouseEvent]) =>
+                  oldEvent.clientX - newEvent.clientX,
+              ),
+              filter((deltaX: number) => deltaX !== 0),
+              tap((deltaX: number) => this.changeCirclePosition(deltaX)),
+              startWith(null),
+              takeUntil(
+                fromEvent(document.body, 'mouseup').pipe(tap(() => this.setDragging(false))),
+              ),
+              last(),
+              tap(
+                () =>
+                  this.circle &&
+                  this.renderer.setStyle(this.circle.nativeElement, 'transition', transition),
+              ),
+            );
+          }),
+          takeUntilDestroyed(this['destroyRef']),
+        )
+        .subscribe((deltaX: number | null) => {
+          deltaX === null ? this.toggle() : this.detectByCoordinates();
+        });
+    }
+  }
 
-	override updateModel(value: boolean | T | null): void {
-		super.updateModel(value);
-		this.setState(!!this.checked);
-	}
+  override updateModel(value: boolean | T | null): void {
+    super.updateModel(value);
+    this.setState(!!this.checked);
+  }
 
-	protected setState(isSelected: boolean): void {
-		isSelected
-			? this.circle &&
-			  this.renderer.setStyle(
-					this.circle.nativeElement,
-					'transform',
-					`translateX(${this.maxPixelValue}px)`,
-			  )
-			: this.circle &&
-			  this.renderer.setStyle(this.circle.nativeElement, 'transform', `translateX(0)`);
-	}
+  protected setState(isSelected: boolean): void {
+    isSelected
+      ? this.circle &&
+        this.renderer.setStyle(
+          this.circle.nativeElement,
+          'transform',
+          `translateX(${this.maxPixelValue}px)`,
+        )
+      : this.circle &&
+        this.renderer.setStyle(this.circle.nativeElement, 'transform', `translateX(0)`);
+  }
 
-	private setDragging(value: boolean): void {
-		this.dragging = value;
-		this.changeDetectorRef.markForCheck();
-	}
+  private setDragging(value: boolean): void {
+    this.dragging = value;
+    this.changeDetectorRef.markForCheck();
+  }
 
-	private detectByCoordinates(): void {
-		if (!this.disabled && this.wrapper && this.circle) {
-			const wrapperMiddle: number =
-				NgDocPositionUtils.getElementPosition(this.wrapper.nativeElement).x +
-				this.wrapper.nativeElement.offsetWidth / 2;
-			const circleCenterLeft: number =
-				NgDocPositionUtils.getElementPosition(this.circle.nativeElement).x +
-				this.circle.nativeElement.offsetWidth / 2;
-			circleCenterLeft > wrapperMiddle ? this.check() : this.uncheck();
-			this.setState(!!this.checked);
-		}
-	}
+  private detectByCoordinates(): void {
+    if (!this.disabled && this.wrapper && this.circle) {
+      const wrapperMiddle: number =
+        NgDocPositionUtils.getElementPosition(this.wrapper.nativeElement).x +
+        this.wrapper.nativeElement.offsetWidth / 2;
+      const circleCenterLeft: number =
+        NgDocPositionUtils.getElementPosition(this.circle.nativeElement).x +
+        this.circle.nativeElement.offsetWidth / 2;
+      circleCenterLeft > wrapperMiddle ? this.check() : this.uncheck();
+      this.setState(!!this.checked);
+    }
+  }
 
-	private changeCirclePosition(delta: number): void {
-		if (this.wrapper && this.circle) {
-			const wrapperLeft: number = NgDocPositionUtils.getElementPosition(
-				this.wrapper.nativeElement,
-			).x;
-			const circleLeft: number = NgDocPositionUtils.getElementPosition(this.circle.nativeElement).x;
-			const newPosition: number = Math.max(
-				Math.min(circleLeft - wrapperLeft - 3 + delta, this.maxPixelValue),
-				0,
-			);
-			this.renderer.setStyle(
-				this.circle.nativeElement,
-				'transform',
-				`translateX(${newPosition}px)`,
-			);
-		}
-	}
+  private changeCirclePosition(delta: number): void {
+    if (this.wrapper && this.circle) {
+      const wrapperLeft: number = NgDocPositionUtils.getElementPosition(
+        this.wrapper.nativeElement,
+      ).x;
+      const circleLeft: number = NgDocPositionUtils.getElementPosition(this.circle.nativeElement).x;
+      const newPosition: number = Math.max(
+        Math.min(circleLeft - wrapperLeft - 3 + delta, this.maxPixelValue),
+        0,
+      );
+      this.renderer.setStyle(
+        this.circle.nativeElement,
+        'transform',
+        `translateX(${newPosition}px)`,
+      );
+    }
+  }
 }

--- a/libs/ui-kit/directives/event-switcher/event-switcher.directive.ts
+++ b/libs/ui-kit/directives/event-switcher/event-switcher.directive.ts
@@ -1,43 +1,47 @@
-import { Directive, ElementRef, Input, NgZone, OnInit } from '@angular/core';
+import { DestroyRef, Directive, ElementRef, inject, Input, NgZone, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { asArray } from '@ng-doc/core/helpers/as-array';
 import { Constructor } from '@ng-doc/core/types';
 import { toElement } from '@ng-doc/ui-kit/helpers';
 import { ngDocZoneDetach } from '@ng-doc/ui-kit/observables';
 import { BaseElement } from '@ng-doc/ui-kit/types';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { fromEvent, merge } from 'rxjs';
 
 @Directive({
-	selector: '[ngDocEventSwitcher]',
-	standalone: true,
+  selector: '[ngDocEventSwitcher]',
+  standalone: true,
 })
-@UntilDestroy()
 export class NgDocEventSwitcherDirective implements OnInit {
-	@Input('ngDocEventSwitcher')
-	switchTo: BaseElement<HTMLElement> | null = null;
+  @Input('ngDocEventSwitcher')
+  switchTo: BaseElement<HTMLElement> | null = null;
 
-	@Input()
-	events: string | string[] = [];
+  @Input()
+  events: string | string[] = [];
 
-	constructor(private elementRef: ElementRef<HTMLElement>, private ngZone: NgZone) {}
+  private readonly destroyRef = inject(DestroyRef);
 
-	ngOnInit(): void {
-		merge(
-			...asArray(this.events).map((eventName: string) =>
-				fromEvent(this.elementRef.nativeElement, eventName),
-			),
-		)
-			.pipe(ngDocZoneDetach(this.ngZone), untilDestroyed(this))
-			.subscribe((event: Event) => {
-				if (this.switchTo && !event.defaultPrevented && event.bubbles) {
-					event.stopPropagation();
-					this.makeEvent(event, toElement(this.switchTo));
-				}
-			});
-	}
+  constructor(
+    private elementRef: ElementRef<HTMLElement>,
+    private ngZone: NgZone,
+  ) {}
 
-	private makeEvent(from: Event, target: Element): void {
-		const eventConstructor: Constructor<Event> = from.constructor as Constructor<Event>;
-		target.dispatchEvent(new eventConstructor(from.type, from));
-	}
+  ngOnInit(): void {
+    merge(
+      ...asArray(this.events).map((eventName: string) =>
+        fromEvent(this.elementRef.nativeElement, eventName),
+      ),
+    )
+      .pipe(ngDocZoneDetach(this.ngZone), takeUntilDestroyed(this.destroyRef))
+      .subscribe((event: Event) => {
+        if (this.switchTo && !event.defaultPrevented && event.bubbles) {
+          event.stopPropagation();
+          this.makeEvent(event, toElement(this.switchTo));
+        }
+      });
+  }
+
+  private makeEvent(from: Event, target: Element): void {
+    const eventConstructor: Constructor<Event> = from.constructor as Constructor<Event>;
+    target.dispatchEvent(new eventConstructor(from.type, from));
+  }
 }

--- a/libs/ui-kit/directives/focus-catcher/focus-catcher.directive.ts
+++ b/libs/ui-kit/directives/focus-catcher/focus-catcher.directive.ts
@@ -1,56 +1,55 @@
 import {
-	ChangeDetectorRef,
-	Directive,
-	ElementRef,
-	EventEmitter,
-	HostBinding,
-	NgZone,
-	Output,
+  ChangeDetectorRef,
+  Directive,
+  ElementRef,
+  EventEmitter,
+  HostBinding,
+  NgZone,
+  Output,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BLUR_EVENT, FOCUS_EVENT } from '@ng-doc/ui-kit/constants';
 import { toElement } from '@ng-doc/ui-kit/helpers';
 import { ngDocZoneOptimize } from '@ng-doc/ui-kit/observables';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { fromEvent, merge, Observable } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
 @Directive({
-	selector: '[ngDocFocusCatcher]',
-	exportAs: 'ngDocFocusCatcher',
-	standalone: true,
+  selector: '[ngDocFocusCatcher]',
+  exportAs: 'ngDocFocusCatcher',
+  standalone: true,
 })
-@UntilDestroy()
 export class NgDocFocusCatcherDirective {
-	@Output()
-	focusEvent: EventEmitter<Event> = new EventEmitter<Event>();
+  @Output()
+  focusEvent: EventEmitter<Event> = new EventEmitter<Event>();
 
-	@Output()
-	blurEvent: EventEmitter<Event> = new EventEmitter<Event>();
+  @Output()
+  blurEvent: EventEmitter<Event> = new EventEmitter<Event>();
 
-	@HostBinding('attr.data-ng-doc-focused')
-	focused: boolean = false;
+  @HostBinding('attr.data-ng-doc-focused')
+  focused: boolean = false;
 
-	constructor(
-		private elementRef: ElementRef<HTMLElement>,
-		private ngZone: NgZone,
-		private changeDetectorRef: ChangeDetectorRef,
-	) {
-		NgDocFocusCatcherDirective.observeFocus(toElement(this.elementRef))
-			.pipe(ngDocZoneOptimize(this.ngZone), untilDestroyed(this))
-			.subscribe((event: FocusEvent) => {
-				this.focused = event.type === FOCUS_EVENT;
-				this.focused ? this.focusEvent.emit(event) : this.blurEvent.emit(event);
-				this.changeDetectorRef.markForCheck();
-			});
-	}
+  constructor(
+    private elementRef: ElementRef<HTMLElement>,
+    private ngZone: NgZone,
+    private changeDetectorRef: ChangeDetectorRef,
+  ) {
+    NgDocFocusCatcherDirective.observeFocus(toElement(this.elementRef))
+      .pipe(ngDocZoneOptimize(this.ngZone), takeUntilDestroyed())
+      .subscribe((event: FocusEvent) => {
+        this.focused = event.type === FOCUS_EVENT;
+        this.focused ? this.focusEvent.emit(event) : this.blurEvent.emit(event);
+        this.changeDetectorRef.markForCheck();
+      });
+  }
 
-	static observeFocus(element: HTMLElement): Observable<FocusEvent> {
-		return merge(
-			fromEvent<FocusEvent>(element, FOCUS_EVENT),
-			fromEvent<FocusEvent>(element, BLUR_EVENT),
-		).pipe(
-			debounceTime(0),
-			distinctUntilChanged((a: FocusEvent, b: FocusEvent) => a.type === b.type),
-		);
-	}
+  static observeFocus(element: HTMLElement): Observable<FocusEvent> {
+    return merge(
+      fromEvent<FocusEvent>(element, FOCUS_EVENT),
+      fromEvent<FocusEvent>(element, BLUR_EVENT),
+    ).pipe(
+      debounceTime(0),
+      distinctUntilChanged((a: FocusEvent, b: FocusEvent) => a.type === b.type),
+    );
+  }
 }

--- a/libs/ui-kit/directives/hotkey/hotkey.directive.ts
+++ b/libs/ui-kit/directives/hotkey/hotkey.directive.ts
@@ -1,46 +1,56 @@
-import { afterNextRender, Directive, EventEmitter, Input, NgZone, Output } from '@angular/core';
+import {
+  afterNextRender,
+  DestroyRef,
+  Directive,
+  EventEmitter,
+  inject,
+  Input,
+  NgZone,
+  Output,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { isKeyboardEvent } from '@ng-doc/core/helpers/is-keyboard-event';
 import { objectKeys } from '@ng-doc/core/helpers/object-keys';
 import { ngDocZoneOptimize } from '@ng-doc/ui-kit/observables';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 @Directive({
-	selector: '[ngDocHotkey]',
-	standalone: true,
+  selector: '[ngDocHotkey]',
+  standalone: true,
 })
-@UntilDestroy()
 export class NgDocHotkeyDirective {
-	@Input('ngDocHotkey')
-	hotkey?: Partial<KeyboardEvent>;
+  @Input('ngDocHotkey')
+  hotkey?: Partial<KeyboardEvent>;
 
-	@Output('ngDocHotkey')
-	callback: EventEmitter<void> = new EventEmitter<void>();
+  @Output('ngDocHotkey')
+  callback: EventEmitter<void> = new EventEmitter<void>();
 
-	constructor(private readonly ngZone: NgZone) {
-		afterNextRender(() => {
-			fromEvent(document, 'keyup')
-				.pipe(
-					filter(isKeyboardEvent),
-					filter((event: KeyboardEvent) =>
-						objectKeys(this.hotkey ?? {}).every(
-							(key: keyof KeyboardEvent) => this.hotkey && this.hotkey[key] === event[key],
-						),
-					),
-					filter((event: KeyboardEvent) => {
-						if (event.target instanceof HTMLElement) {
-							return !['input', 'textarea', 'select'].includes(event.target.tagName.toLowerCase());
-						}
-						return true;
-					}),
-					ngDocZoneOptimize(this.ngZone),
-					untilDestroyed(this),
-				)
-				.subscribe((event: KeyboardEvent) => {
-					event.preventDefault();
-					this.callback.emit();
-				});
-		});
-	}
+  constructor(private readonly ngZone: NgZone) {
+    const destroyRef = inject(DestroyRef);
+
+    afterNextRender(() => {
+      fromEvent(document, 'keyup')
+        .pipe(
+          filter(isKeyboardEvent),
+          filter((event: KeyboardEvent) =>
+            objectKeys(this.hotkey ?? {}).every(
+              (key: keyof KeyboardEvent) => this.hotkey && this.hotkey[key] === event[key],
+            ),
+          ),
+          filter((event: KeyboardEvent) => {
+            if (event.target instanceof HTMLElement) {
+              return !['input', 'textarea', 'select'].includes(event.target.tagName.toLowerCase());
+            }
+            return true;
+          }),
+          ngDocZoneOptimize(this.ngZone),
+          takeUntilDestroyed(destroyRef),
+        )
+        .subscribe((event: KeyboardEvent) => {
+          event.preventDefault();
+          this.callback.emit();
+        });
+    });
+  }
 }

--- a/libs/ui-kit/directives/input-number/input-number.directive.ts
+++ b/libs/ui-kit/directives/input-number/input-number.directive.ts
@@ -2,32 +2,30 @@ import { Directive, forwardRef, HostListener } from '@angular/core';
 import { isPresent } from '@ng-doc/core/helpers/is-present';
 import { NgDocBaseInput } from '@ng-doc/ui-kit/classes/base-input';
 import { toElement } from '@ng-doc/ui-kit/helpers';
-import { UntilDestroy } from '@ngneat/until-destroy';
 
 @Directive({
-	selector: `input[ngDocInputNumber]`,
-	providers: [
-		{ provide: NgDocBaseInput, useExisting: forwardRef(() => NgDocInputNumberDirective) },
-	],
-	standalone: true,
+  selector: `input[ngDocInputNumber]`,
+  providers: [
+    { provide: NgDocBaseInput, useExisting: forwardRef(() => NgDocInputNumberDirective) },
+  ],
+  standalone: true,
 })
-@UntilDestroy()
 export class NgDocInputNumberDirective extends NgDocBaseInput<number> {
-	constructor() {
-		super({
-			onIncomingUpdate: (value) => {
-				toElement(this.elementRef).value = isPresent(value) ? String(Number(value)) : '';
-			},
-		});
-	}
+  constructor() {
+    super({
+      onIncomingUpdate: (value) => {
+        toElement(this.elementRef).value = isPresent(value) ? String(Number(value)) : '';
+      },
+    });
+  }
 
-	@HostListener('blur')
-	blurEvent(): void {
-		this.touch();
-	}
+  @HostListener('blur')
+  blurEvent(): void {
+    this.touch();
+  }
 
-	@HostListener('input')
-	inputEvent(): void {
-		this.updateModel(Number(this.elementRef.nativeElement.value));
-	}
+  @HostListener('input')
+  inputEvent(): void {
+    this.updateModel(Number(this.elementRef.nativeElement.value));
+  }
 }

--- a/libs/ui-kit/directives/input-string/input-string.directive.ts
+++ b/libs/ui-kit/directives/input-string/input-string.directive.ts
@@ -2,33 +2,31 @@ import { Directive, forwardRef, HostListener } from '@angular/core';
 import { isPresent } from '@ng-doc/core/helpers/is-present';
 import { NgDocBaseInput } from '@ng-doc/ui-kit/classes/base-input';
 import { toElement } from '@ng-doc/ui-kit/helpers';
-import { UntilDestroy } from '@ngneat/until-destroy';
 
 /** Directive converts any input data or model to text */
 @Directive({
-	selector: `input[ngDocInputString]`,
-	providers: [
-		{ provide: NgDocBaseInput, useExisting: forwardRef(() => NgDocInputStringDirective) },
-	],
-	standalone: true,
+  selector: `input[ngDocInputString]`,
+  providers: [
+    { provide: NgDocBaseInput, useExisting: forwardRef(() => NgDocInputStringDirective) },
+  ],
+  standalone: true,
 })
-@UntilDestroy()
 export class NgDocInputStringDirective extends NgDocBaseInput<string> {
-	constructor() {
-		super({
-			onIncomingUpdate: (value) => {
-				toElement(this.elementRef).value = isPresent(value) ? String(value) : '';
-			},
-		});
-	}
+  constructor() {
+    super({
+      onIncomingUpdate: (value) => {
+        toElement(this.elementRef).value = isPresent(value) ? String(value) : '';
+      },
+    });
+  }
 
-	@HostListener('blur')
-	blurEvent(): void {
-		this.touch();
-	}
+  @HostListener('blur')
+  blurEvent(): void {
+    this.touch();
+  }
 
-	@HostListener('input')
-	inputEvent(): void {
-		this.updateModel(this.elementRef.nativeElement.value);
-	}
+  @HostListener('input')
+  inputEvent(): void {
+    this.updateModel(this.elementRef.nativeElement.value);
+  }
 }

--- a/libs/ui-kit/package.json
+++ b/libs/ui-kit/package.json
@@ -5,7 +5,6 @@
     "@angular/common": ">=19.0.0 < 20.0.0",
     "@angular/core": ">=19.0.0 < 20.0.0",
     "@angular/cdk": ">=19.0.0 < 20.0.0",
-    "@ngneat/until-destroy": "^10.0.0",
     "di-controls": "2.1.0",
     "@tinkoff/ng-polymorpheus": "4.3.0",
     "rxjs": "^7.0.0"

--- a/libs/ui-kit/services/notify/notify.service.ts
+++ b/libs/ui-kit/services/notify/notify.service.ts
@@ -1,46 +1,45 @@
 import { Injectable } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { notificationCloseAnimation, notificationOpenAnimation } from '@ng-doc/ui-kit/animations';
 import { NgDocOverlayRef } from '@ng-doc/ui-kit/classes';
 import { NgDocOverlayContainerComponent } from '@ng-doc/ui-kit/components/overlay-container';
 import { NgDocOverlayService } from '@ng-doc/ui-kit/services/overlay';
 import { NgDocContent } from '@ng-doc/ui-kit/types';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Subject, timer } from 'rxjs';
 import { switchMap, tap } from 'rxjs/operators';
 
 @Injectable({
-	providedIn: 'root',
+  providedIn: 'root',
 })
-@UntilDestroy()
 export class NgDocNotifyService {
-	private overlayRef?: NgDocOverlayRef;
-	private readonly notify$: Subject<NgDocContent> = new Subject<NgDocContent>();
+  private overlayRef?: NgDocOverlayRef;
+  private readonly notify$: Subject<NgDocContent> = new Subject<NgDocContent>();
 
-	constructor(private readonly overlayService: NgDocOverlayService) {
-		this.notify$
-			.pipe(
-				tap(() => this.overlayRef?.close()),
-				tap((content: NgDocContent) => this.openOverlay(content)),
-				switchMap(() => timer(2000)),
-				untilDestroyed(this),
-			)
-			.subscribe(() => this.overlayRef?.close());
-	}
+  constructor(private readonly overlayService: NgDocOverlayService) {
+    this.notify$
+      .pipe(
+        tap(() => this.overlayRef?.close()),
+        tap((content: NgDocContent) => this.openOverlay(content)),
+        switchMap(() => timer(2000)),
+        takeUntilDestroyed(),
+      )
+      .subscribe(() => this.overlayRef?.close());
+  }
 
-	notify(content: NgDocContent): void {
-		this.notify$.next(content);
-	}
+  notify(content: NgDocContent): void {
+    this.notify$.next(content);
+  }
 
-	private openOverlay(content: NgDocContent): void {
-		this.overlayRef = this.overlayService.open(content, {
-			overlayContainer: NgDocOverlayContainerComponent,
-			panelClass: 'ng-doc-notify',
-			positionStrategy: this.overlayService
-				.globalPositionStrategy()
-				.bottom('10px')
-				.centerHorizontally(),
-			openAnimation: notificationOpenAnimation,
-			closeAnimation: notificationCloseAnimation,
-		});
-	}
+  private openOverlay(content: NgDocContent): void {
+    this.overlayRef = this.overlayService.open(content, {
+      overlayContainer: NgDocOverlayContainerComponent,
+      panelClass: 'ng-doc-notify',
+      positionStrategy: this.overlayService
+        .globalPositionStrategy()
+        .bottom('10px')
+        .centerHorizontally(),
+      openAnimation: notificationOpenAnimation,
+      closeAnimation: notificationCloseAnimation,
+    });
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@angular/ssr": "19.0.4",
         "@microsoft/tsdoc": "0.15.1",
         "@ng-web-apis/common": "2.0.1",
-        "@ngneat/until-destroy": "^10.0.0",
         "@orama/orama": "2.0.17",
         "@orama/plugin-match-highlight": "2.0.17",
         "@orama/plugin-parsedoc": "2.0.17",
@@ -6985,19 +6984,6 @@
         "@angular/common": ">=12.0.0",
         "@angular/core": ">=12.0.0",
         "rxjs": ">=6.4.0"
-      }
-    },
-    "node_modules/@ngneat/until-destroy": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@ngneat/until-destroy/-/until-destroy-10.0.0.tgz",
-      "integrity": "sha512-xXFAabQ4YVJ82LYxdgUlaKZyR3dSbxqG3woSyaclzxfCgWMEDweCcM/GGYbNiHJa0WwklI98RXHvca+UyCxpeg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/core": ">=13",
-        "rxjs": "^6.4.0 || ^7.0.0"
       }
     },
     "node_modules/@ngtools/webpack": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@angular/ssr": "19.0.4",
     "@microsoft/tsdoc": "0.15.1",
     "@ng-web-apis/common": "2.0.1",
-    "@ngneat/until-destroy": "^10.0.0",
     "@orama/orama": "2.0.17",
     "@orama/plugin-match-highlight": "2.0.17",
     "@orama/plugin-parsedoc": "2.0.17",


### PR DESCRIPTION
In this commit, we replace `@ngneat/until-destroy` with `takeUntilDestroyed()`. Since this functionality has been released in Angular, I'm no longer maintaining the `until-destroy` package, and we tend to advise people to migrate to the built-in functionality that Angular now exports.