### PR TITLE
fix: guard nativeElement.animate() against SSG in overlay container

### DIFF
--- a/libs/ui-kit/components/overlay-container/overlay-container.component.ts
+++ b/libs/ui-kit/components/overlay-container/overlay-container.component.ts
@@ -2,6 +2,7 @@ import {
   ConnectedOverlayPositionChange,
   FlexibleConnectedPositionStrategy,
 } from '@angular/cdk/overlay';
+import { isPlatformBrowser } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -15,6 +16,7 @@ import {
   NgZone,
   OnDestroy,
   OnInit,
+  PLATFORM_ID,
   ViewChild,
 } from '@angular/core';
 import { NgDocFocusControlComponent } from '@ng-doc/ui-kit/components/focus-control';
@@ -57,6 +59,7 @@ export class NgDocOverlayContainerComponent
   private documentRef = inject<Document>(DOCUMENT);
   private changeDetectorRef = inject(ChangeDetectorRef);
   private ngZone = inject(NgZone);
+  private platformId = inject(PLATFORM_ID);
 
   @Input()
   content: NgDocContent = '';
@@ -155,6 +158,11 @@ export class NgDocOverlayContainerComponent
     close: boolean = false,
   ): void {
     this.animationEvent$.next(close ? 'beforeClose' : 'beforeOpen');
+
+    if (!isPlatformBrowser(this.platformId)) {
+      this.animationEvent$.next(close ? 'afterClose' : 'afterOpen');
+      return;
+    }
 
     this.elementRef.nativeElement
       .animate(keyframes, options)


### PR DESCRIPTION
Fixes #323

Injects `PLATFORM_ID` in `NgDocOverlayContainerComponent` and guards the `nativeElement.animate()` call in `runAnimation` with `isPlatformBrowser()`.  
On the server, the animation is skipped and `afterOpen`/`afterClose` events are emitted immediately so the overlay lifecycle is not broken.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number

<!-- Bugs and features must be linked to an issue. -->

Issue Number: #323

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
