### PR TITLE
fix(app): types declaration error

### DIFF
--- a/libs/app/components/playground/playground-properties/playground-properties.component.ts
+++ b/libs/app/components/playground/playground-properties/playground-properties.component.ts
@@ -151,7 +151,7 @@ export class NgDocPlaygroundPropertiesComponent<
     }
   }
 
-  getFormControl(controlType: keyof typeof this.form.controls, key: string): FormControl {
+  getFormControl(controlType: keyof NgDocPlaygroundForm, key: string): FormControl {
     return this.form.get(controlType)?.get(key) as FormControl;
   }
 


### PR DESCRIPTION
Fixes compilor error when serving application that utilises `ng-doc`.

While referencing the class instance `this` in a type declaration is valid, it's not valid in a `.d.ts` context. `.d.ts` has no class, thus Typescript supposedly replaces it with `this$1`, but that's not declared anyway, causing project errors, unless the user has `skipLibCheck` enabled.

Not sure why no one else has come across this issue. Perhaps everyone is using `skipLibCheck: true` in their project's tsconfig.json? I hope not.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ]  ~Tests for the changes have been added (for bug fixes/features)~
- [ ] ~Docs have been added/updated (for bug fixes/features)~

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number

Issue Number: [317](https://github.com/ng-doc/ng-doc/issues/317)

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
