### PR TITLE
fix(builder): pass { dot: true } to minimatch to support dot-directories in file paths

### DIFF
--- a/libs/builder/engine/builders/helpers/create-entry-metadata.ts
+++ b/libs/builder/engine/builders/helpers/create-entry-metadata.ts
@@ -35,7 +35,7 @@ export function createEntryMetadata<T extends FileEntry>(
   const route = getEntryRoute(entry, entryPath);
   const categorySourceFile = entry.category && getCategorySourceFile(sourceFile);
   const outDir = getEntryOutDir(context, entry, entryPath);
-  const isCategory = minimatch(entryPath, CATEGORY_PATTERN);
+  const isCategory = minimatch(entryPath, CATEGORY_PATTERN, { dot: true });
 
   return {
     id: `entry${Math.random().toString(36).substring(2)}`,

--- a/libs/builder/engine/builders/interfaces/entry-metadata.ts
+++ b/libs/builder/engine/builders/interfaces/entry-metadata.ts
@@ -48,5 +48,5 @@ export type ParentEntryMetadata<T extends Entry> = T extends NgDocPage
  * @param entry
  */
 export function isPageEntryMetadata(entry: EntryMetadata): entry is EntryMetadata<NgDocPage> {
-  return minimatch(entry.path, PAGE_PATTERN);
+  return minimatch(entry.path, PAGE_PATTERN, { dot: true });
 }

--- a/libs/builder/engine/builders/interfaces/entry.ts
+++ b/libs/builder/engine/builders/interfaces/entry.ts
@@ -27,7 +27,7 @@ export type Entry = ContentEntry | NgDocCategory;
  * @param filePath
  */
 export function isPageEntry(entry: Entry, filePath: string): entry is NgDocPage {
-  return minimatch(filePath, PAGE_PATTERN);
+  return minimatch(filePath, PAGE_PATTERN, { dot: true });
 }
 
 /**
@@ -36,7 +36,7 @@ export function isPageEntry(entry: Entry, filePath: string): entry is NgDocPage 
  * @param filePath
  */
 export function isCategoryEntry(entry: Entry, filePath: string): entry is NgDocCategory {
-  return minimatch(filePath, CATEGORY_PATTERN);
+  return minimatch(filePath, CATEGORY_PATTERN, { dot: true });
 }
 
 /**
@@ -45,5 +45,5 @@ export function isCategoryEntry(entry: Entry, filePath: string): entry is NgDocC
  * @param filePath
  */
 export function isApiEntry(entry: Entry, filePath: string): entry is NgDocApi {
-  return minimatch(filePath, API_PATTERN);
+  return minimatch(filePath, API_PATTERN, { dot: true });
 }

--- a/libs/builder/engine/builders/interfaces/testing/entry.spec.ts
+++ b/libs/builder/engine/builders/interfaces/testing/entry.spec.ts
@@ -1,0 +1,72 @@
+import { isApiEntry, isCategoryEntry, isPageEntry } from '../entry';
+
+describe('entry type guards', () => {
+  describe('isPageEntry', () => {
+    it('should match a standard path', () => {
+      expect(
+        isPageEntry({} as any, '/home/user/projects/app/docs/installation/ng-doc.page.ts'),
+      ).toBe(true);
+    });
+
+    it('should match a path containing a dot-directory', () => {
+      expect(
+        isPageEntry(
+          {} as any,
+          '/home/user/projects/app/.worktrees/my-branch/docs/installation/ng-doc.page.ts',
+        ),
+      ).toBe(true);
+    });
+
+    it('should not match a non-page file', () => {
+      expect(
+        isPageEntry({} as any, '/home/user/projects/app/docs/installation/ng-doc.category.ts'),
+      ).toBe(false);
+    });
+  });
+
+  describe('isCategoryEntry', () => {
+    it('should match a standard path', () => {
+      expect(
+        isCategoryEntry({} as any, '/home/user/projects/app/docs/installation/ng-doc.category.ts'),
+      ).toBe(true);
+    });
+
+    it('should match a path containing a dot-directory', () => {
+      expect(
+        isCategoryEntry(
+          {} as any,
+          '/home/user/projects/app/.worktrees/my-branch/docs/installation/ng-doc.category.ts',
+        ),
+      ).toBe(true);
+    });
+
+    it('should not match a non-category file', () => {
+      expect(
+        isCategoryEntry({} as any, '/home/user/projects/app/docs/installation/ng-doc.page.ts'),
+      ).toBe(false);
+    });
+  });
+
+  describe('isApiEntry', () => {
+    it('should match a standard path', () => {
+      expect(isApiEntry({} as any, '/home/user/projects/app/docs/installation/ng-doc.api.ts')).toBe(
+        true,
+      );
+    });
+
+    it('should match a path containing a dot-directory', () => {
+      expect(
+        isApiEntry(
+          {} as any,
+          '/home/user/projects/app/.worktrees/my-branch/docs/installation/ng-doc.api.ts',
+        ),
+      ).toBe(true);
+    });
+
+    it('should not match a non-api file', () => {
+      expect(
+        isApiEntry({} as any, '/home/user/projects/app/docs/installation/ng-doc.page.ts'),
+      ).toBe(false);
+    });
+  });
+});

--- a/libs/builder/engine/core/operators/entries-emitter.ts
+++ b/libs/builder/engine/core/operators/entries-emitter.ts
@@ -31,11 +31,11 @@ export function entriesEmitter(
     map((events) =>
       events
         .map((filePath) => {
-          if (minimatch(filePath, PAGE_PATTERN)) {
+          if (minimatch(filePath, PAGE_PATTERN, { dot: true })) {
             return pageBuilder(context, path.resolve(filePath));
           }
 
-          if (minimatch(filePath, API_PATTERN)) {
+          if (minimatch(filePath, API_PATTERN, { dot: true })) {
             return apiBuilder(context, path.resolve(filePath));
           }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number

<!-- Bugs and features must be linked to an issue. -->

Issue Number: #326

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information

Passes { dot: true } to all minimatch calls that receive absolute file paths, allowing patterns like **/ng-doc.page.ts to match paths containing dot-directories (e.g. .claude/). Without this option, minimatch skips dot-directory segments when resolving ** globs.