### PR TITLE
fix: update polymorpheus to rebranded version

### DIFF
--- a/apps/ng-doc/src/app/pages/landing/tile/tile.component.ts
+++ b/apps/ng-doc/src/app/pages/landing/tile/tile.component.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
 import { NgDocContent, NgDocOrientation } from '@ng-doc/ui-kit';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 
 @Component({
   selector: 'ng-doc-tile',
   standalone: true,
-  imports: [CommonModule, PolymorpheusModule],
+  imports: [CommonModule, PolymorpheusOutlet],
   template: `
     @if (media) {
       <div class="ng-doc-tile-media">

--- a/libs/app/components/navbar/navbar.component.ts
+++ b/libs/app/components/navbar/navbar.component.ts
@@ -14,7 +14,7 @@ import { NgDocSearchComponent } from '@ng-doc/app/components/search';
 import { NgDocSidebarService } from '@ng-doc/app/services';
 import { NgDocButtonIconComponent, NgDocIconComponent, ngDocZoneOptimize } from '@ng-doc/ui-kit';
 import { WA_WINDOW } from '@ng-web-apis/common';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 import { combineLatest, fromEvent } from 'rxjs';
 import { distinctUntilChanged, map, startWith } from 'rxjs/operators';
 
@@ -26,7 +26,7 @@ import { distinctUntilChanged, map, startWith } from 'rxjs/operators';
   templateUrl: './navbar.component.html',
   styleUrls: ['./navbar.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [PolymorpheusModule, NgDocSearchComponent, NgDocButtonIconComponent, NgDocIconComponent],
+  imports: [PolymorpheusOutlet, NgDocSearchComponent, NgDocButtonIconComponent, NgDocIconComponent],
 })
 export class NgDocNavbarComponent {
   private readonly window = inject<Window>(WA_WINDOW);

--- a/libs/app/components/root/root.component.ts
+++ b/libs/app/components/root/root.component.ts
@@ -10,7 +10,7 @@ import {
 } from '@angular/core';
 import { NgDocSidebarService } from '@ng-doc/app/services';
 import { NgDocContent, NgDocSidenavComponent } from '@ng-doc/ui-kit';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 
 /**
  * Directive uses for providing custom navbar, you should mark element with this directive
@@ -56,7 +56,7 @@ export class NgDocCustomSidebarDirective {}
   styleUrls: ['./root.component.scss'],
   providers: [],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgDocSidenavComponent, PolymorpheusModule, AsyncPipe],
+  imports: [NgDocSidenavComponent, PolymorpheusOutlet, AsyncPipe],
 })
 export class NgDocRootComponent {
   /**

--- a/libs/app/components/sidebar/sidebar-category/sidebar-category.component.ts
+++ b/libs/app/components/sidebar/sidebar-category/sidebar-category.component.ts
@@ -18,7 +18,7 @@ import {
   NgDocTextComponent,
   NgDocTextLeftDirective,
 } from '@ng-doc/ui-kit';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 
 @Component({
   selector: 'ng-doc-sidebar-category',
@@ -33,7 +33,7 @@ import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
     NgDocTextLeftDirective,
     NgDocRotatorDirective,
     NgDocExpanderComponent,
-    PolymorpheusModule,
+    PolymorpheusOutlet,
   ],
 })
 export class NgDocSidebarCategoryComponent {

--- a/libs/ui-kit/components/combobox/combobox.component.ts
+++ b/libs/ui-kit/components/combobox/combobox.component.ts
@@ -16,7 +16,7 @@ import { NgDocFocusCatcherDirective } from '@ng-doc/ui-kit/directives/focus-catc
 import { NgDocInputStringDirective } from '@ng-doc/ui-kit/directives/input-string';
 import { NgDocContextWithImplicit } from '@ng-doc/ui-kit/interfaces';
 import { NgDocContent } from '@ng-doc/ui-kit/types';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 import { DIControl, provideHostControl } from 'di-controls';
 
 @Component({
@@ -36,7 +36,7 @@ import { DIControl, provideHostControl } from 'di-controls';
     NgDocInputWrapperComponent,
     NgDocFocusCatcherDirective,
     NgDocInputStringDirective,
-    PolymorpheusModule,
+    PolymorpheusOutlet,
     NgDocClearControlComponent,
     NgDocDropdownComponent,
     NgTemplateOutlet,

--- a/libs/ui-kit/components/data-list-group/data-list-group.component.ts
+++ b/libs/ui-kit/components/data-list-group/data-list-group.component.ts
@@ -11,7 +11,7 @@ import { NG_DOC_DEFAULT_STRINGIFY } from '@ng-doc/ui-kit/constants';
 import { ngDocMakePure } from '@ng-doc/ui-kit/decorators';
 import { NgDocContextWithImplicit } from '@ng-doc/ui-kit/interfaces';
 import { NgDocContent, NgDocGroupFn } from '@ng-doc/ui-kit/types';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 
 @Component({
   selector: 'ng-doc-data-list-group',
@@ -21,7 +21,7 @@ import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
   imports: [
     NgDocListComponent,
     NgDocOptionGroupComponent,
-    PolymorpheusModule,
+    PolymorpheusOutlet,
     NgDocOptionGroupHeaderDirective,
     NgDocOptionComponent,
     NgDocTextComponent,

--- a/libs/ui-kit/components/data-list/data-list.component.ts
+++ b/libs/ui-kit/components/data-list/data-list.component.ts
@@ -11,14 +11,14 @@ import {
 import { ngDocMakePure } from '@ng-doc/ui-kit/decorators';
 import { NgDocContextWithImplicit } from '@ng-doc/ui-kit/interfaces';
 import { NgDocBooleanHandler, NgDocContent, NgDocDefineValueFunction } from '@ng-doc/ui-kit/types';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 
 @Component({
   selector: 'ng-doc-data-list',
   templateUrl: './data-list.component.html',
   styleUrls: ['./data-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgDocListComponent, NgDocOptionComponent, PolymorpheusModule, NgDocTextComponent],
+  imports: [NgDocListComponent, NgDocOptionComponent, PolymorpheusOutlet, NgDocTextComponent],
 })
 export class NgDocDataListComponent<T> {
   @Input()

--- a/libs/ui-kit/components/expander/expander.component.ts
+++ b/libs/ui-kit/components/expander/expander.component.ts
@@ -1,6 +1,6 @@
 import { AnimationCallbackEvent, ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { NgDocContent } from '@ng-doc/ui-kit/types';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 
 /** Component helps to expand or collapse content */
 @Component({
@@ -8,7 +8,7 @@ import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
   templateUrl: './expander.component.html',
   styleUrls: ['./expander.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [PolymorpheusModule],
+  imports: [PolymorpheusOutlet],
 })
 export class NgDocExpanderComponent {
   /** Change expand state */

--- a/libs/ui-kit/components/input-wrapper/input-wrapper.component.ts
+++ b/libs/ui-kit/components/input-wrapper/input-wrapper.component.ts
@@ -18,7 +18,7 @@ import { ngDocMakePure } from '@ng-doc/ui-kit/decorators';
 import { NgDocFocusCatcherDirective } from '@ng-doc/ui-kit/directives/focus-catcher';
 import { NgDocContextWithImplicit } from '@ng-doc/ui-kit/interfaces';
 import { NgDocContent, NgDocTextAlign } from '@ng-doc/ui-kit/types';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 
 @Component({
   selector: 'ng-doc-input-wrapper',
@@ -35,7 +35,7 @@ import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
     NgDocWrapperComponent,
     NgDocFocusCatcherDirective,
     NgDocFloatedBorderComponent,
-    PolymorpheusModule,
+    PolymorpheusOutlet,
   ],
 })
 export class NgDocInputWrapperComponent<T, B = unknown>

--- a/libs/ui-kit/components/label/label.component.ts
+++ b/libs/ui-kit/components/label/label.component.ts
@@ -1,13 +1,13 @@
 import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
 import { NgDocContent, NgDocHorizontalAlign } from '@ng-doc/ui-kit/types';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 
 @Component({
   selector: 'label[ng-doc-label]',
   templateUrl: './label.component.html',
   styleUrls: ['./label.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [PolymorpheusModule],
+  imports: [PolymorpheusOutlet],
 })
 export class NgDocLabelComponent {
   @Input('ng-doc-label')

--- a/libs/ui-kit/components/overlay-container/overlay-container.component.ts
+++ b/libs/ui-kit/components/overlay-container/overlay-container.component.ts
@@ -35,7 +35,7 @@ import {
   NgDocVerticalAlign,
 } from '@ng-doc/ui-kit/types';
 import { NgDocFocusUtils, NgDocOverlayUtils } from '@ng-doc/ui-kit/utils';
-import { PolymorpheusModule, PolymorpheusOutletDirective } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 import { Observable, Subject } from 'rxjs';
 import { distinctUntilChanged } from 'rxjs/operators';
 
@@ -49,7 +49,7 @@ import { distinctUntilChanged } from 'rxjs/operators';
     NgDocEventSwitcherDirective,
     NgDocFocusControlComponent,
     NgDocFocusCatcherDirective,
-    PolymorpheusModule,
+    PolymorpheusOutlet,
   ],
 })
 export class NgDocOverlayContainerComponent
@@ -73,8 +73,8 @@ export class NgDocOverlayContainerComponent
   @ViewChild(NgDocFocusCatcherDirective)
   focusCatcher?: NgDocFocusCatcherDirective;
 
-  @ViewChild(PolymorpheusOutletDirective, { static: true })
-  outlet?: PolymorpheusOutletDirective<object>;
+  @ViewChild(PolymorpheusOutlet, { static: true })
+  outlet?: PolymorpheusOutlet<object>;
 
   @HostBinding('attr.data-ng-doc-overlay-position')
   relativePosition: NgDocOverlayRelativePosition | null = null;

--- a/libs/ui-kit/components/sidenav/sidenav.component.ts
+++ b/libs/ui-kit/components/sidenav/sidenav.component.ts
@@ -7,14 +7,14 @@ import {
   Output,
 } from '@angular/core';
 import { NgDocContent } from '@ng-doc/ui-kit/types';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 
 @Component({
   selector: 'ng-doc-sidenav',
   templateUrl: './sidenav.component.html',
   styleUrls: ['./sidenav.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [PolymorpheusModule],
+  imports: [PolymorpheusOutlet],
   host: {
     '[attr.data-ng-doc-sidebar]': '!!sidebar',
   },

--- a/libs/ui-kit/components/tab-group/tab-group.component.ts
+++ b/libs/ui-kit/components/tab-group/tab-group.component.ts
@@ -18,7 +18,7 @@ import {
   NgDocSelectionHostDirective,
   NgDocSelectionOriginDirective,
 } from '@ng-doc/ui-kit/components/selection';
-import { PolymorpheusModule } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusOutlet } from '@taiga-ui/polymorpheus';
 import { startWith } from 'rxjs/operators';
 
 import { NgDocTabComponent } from './tab/tab.component';
@@ -32,7 +32,7 @@ import { NgDocTabComponent } from './tab/tab.component';
     NgDocSelectionHostDirective,
     NgDocSelectionComponent,
     NgDocSelectionOriginDirective,
-    PolymorpheusModule,
+    PolymorpheusOutlet,
   ],
 })
 export class NgDocTabGroupComponent<T = number> implements AfterContentInit, AfterViewInit {

--- a/libs/ui-kit/package.json
+++ b/libs/ui-kit/package.json
@@ -6,7 +6,7 @@
     "@angular/core": ">=21.0.0 < 22.0.0",
     "@angular/cdk": ">=21.0.0 < 22.0.0",
     "di-controls": "2.1.0",
-    "@tinkoff/ng-polymorpheus": "4.3.0",
+    "@taiga-ui/polymorpheus": "^5.0.0",
     "rxjs": "^7.0.0"
   },
   "dependencies": {

--- a/libs/ui-kit/services/overlay/overlay.service.ts
+++ b/libs/ui-kit/services/overlay/overlay.service.ts
@@ -13,7 +13,7 @@ import { NgDocOverlayRef } from '@ng-doc/ui-kit/classes';
 import { NgDocOverlayConfig, NgDocOverlayContainer } from '@ng-doc/ui-kit/interfaces';
 import { NgDocContent, NgDocOverlayOrigin, NgDocOverlayPosition } from '@ng-doc/ui-kit/types';
 import { NgDocOverlayUtils } from '@ng-doc/ui-kit/utils';
-import { PolymorpheusComponent } from '@tinkoff/ng-polymorpheus';
+import { PolymorpheusComponent } from '@taiga-ui/polymorpheus';
 import { take } from 'rxjs/operators';
 
 @Injectable({ providedIn: 'root' })

--- a/libs/ui-kit/types/content.ts
+++ b/libs/ui-kit/types/content.ts
@@ -4,7 +4,7 @@ import {
   PolymorpheusComponent,
   PolymorpheusHandler,
   PolymorpheusTemplate,
-} from '@tinkoff/ng-polymorpheus';
+} from '@taiga-ui/polymorpheus';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type NgDocContent<C extends object = {}> =
@@ -21,7 +21,7 @@ export type NgDocContent<C extends object = {}> =
 export class NgDocComponentContent<
   T extends object,
   C extends object = object,
-> extends PolymorpheusComponent<T, C> {
+> extends PolymorpheusComponent<T> {
   constructor(
     override readonly component: Type<T>,
     readonly injectorRef?: Injector,

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@schematics/angular": "21.0.4",
         "@shikijs/rehype": "1.10.3",
         "@stackblitz/sdk": "1.6.0",
-        "@tinkoff/ng-polymorpheus": "4.3.0",
+        "@taiga-ui/polymorpheus": "5.0.1",
         "@types/svgo": "2.6.3",
         "chalk": "5.2.0",
         "cosmiconfig": "8.2.0",
@@ -12607,24 +12607,18 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
-    "node_modules/@tinkoff/ng-polymorpheus": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tinkoff/ng-polymorpheus/-/ng-polymorpheus-4.3.0.tgz",
-      "integrity": "sha512-Ck/XCLuBwlUgvK22PxTlLTZhGG6I32kLqLYtDQh8N/QZZhs40+hb/78/ElFGzD567CCvrzNnueFkaOoXhuEVrw==",
+    "node_modules/@taiga-ui/polymorpheus": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@taiga-ui/polymorpheus/-/polymorpheus-5.0.1.tgz",
+      "integrity": "sha512-OpPuPjkfwZDZmLIBrjWRpSCSCjqIS8y2/ntACe8ySe17Fz8zTAj6gXP5TKqsrfla0mzWpN1A6Hz8YR6jDhV8qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "2.6.2"
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
-        "@angular/core": ">=12.0.0",
-        "@angular/platform-browser": ">=12.0.0"
+        "@angular/core": ">=19.0.0",
+        "@angular/platform-browser": ">=19.0.0"
       }
-    },
-    "node_modules/@tinkoff/ng-polymorpheus/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "license": "0BSD"
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@schematics/angular": "21.0.4",
     "@shikijs/rehype": "1.10.3",
     "@stackblitz/sdk": "1.6.0",
-    "@tinkoff/ng-polymorpheus": "4.3.0",
+    "@taiga-ui/polymorpheus": "5.0.1",
     "@types/svgo": "2.6.3",
     "chalk": "5.2.0",
     "cosmiconfig": "8.2.0",


### PR DESCRIPTION
The package `@tinkoff/ng-polymorpheus` last update was 3 years ago and is not compatible with Angular 22.

This replace it with it's updated rebranded package `@taiga-ui/polymorpheus`.

It would probably be better to merge in some angular-22 branch to ensure other things work first before merging this to main due to the breaking change.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number

<!-- Bugs and features must be linked to an issue. -->

Issue Number: #328

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

Apps need to remove `@tinkoff/ng-polymorpheus` and add `@taiga-ui/polymorpheus`.

## Other information
