### PR TITLE
fix(builder): resolve paths relative to ng workspace instead of cwd

### DIFF
--- a/apps/ng-doc/docs/api-documentation/rendering-api/index.md
+++ b/apps/ng-doc/docs/api-documentation/rendering-api/index.md
@@ -4,6 +4,11 @@ keywords: RenderingApiPage
 
 NgDoc supports rendering API information in your guides.
 
+> **Note**
+> Declaration paths are resolved in the following order:
+> relative to the `rootDir` specified in your `tsconfig.json` first,
+> then relative to the page file's directory.
+
 ## API rendering
 
 To render API information you can use the `NgDocApi` class that provides methods to generate

--- a/libs/builder/engine/nunjucks/actions/api-details.action.ts
+++ b/libs/builder/engine/nunjucks/actions/api-details.action.ts
@@ -10,8 +10,7 @@ import { NgDocAction } from '../../../types';
  */
 export function apiDetailsAction(declarationPath: string): NgDocAction<string> {
   return (entry) => {
-    const project = entry.sourceFile.getProject();
-    const declaration = getDeclarationByPath(project, declarationPath);
+    const declaration = getDeclarationByPath(entry, declarationPath);
     const kindName = kebabCase(declaration.getKindName());
     const output = renderTemplate(`./api/details/${kindName}.html.nunj`, {
       context: {

--- a/libs/builder/engine/nunjucks/actions/api.action.ts
+++ b/libs/builder/engine/nunjucks/actions/api.action.ts
@@ -11,8 +11,7 @@ import { NgDocAction } from '../../../types';
  */
 export function apiAction(declarationPath: string): NgDocAction<string> {
   return (entry) => {
-    const project = entry.sourceFile.getProject();
-    const declaration = getDeclarationByPath(project, declarationPath);
+    const declaration = getDeclarationByPath(entry, declarationPath);
     const declarationName = declaration.getName() || '[Unknown]';
     const kindName = kebabCase(declaration.getKindName());
     const output = renderTemplate(`./api/${kindName}.html.nunj`, {

--- a/libs/builder/engine/nunjucks/actions/js-doc-has-tag.action.ts
+++ b/libs/builder/engine/nunjucks/actions/js-doc-has-tag.action.ts
@@ -10,8 +10,7 @@ import { NgDocAction } from '../../../types';
  */
 export function jsDocHasTagAction(declarationPath: string, tagName: string): NgDocAction<boolean> {
   return (entry) => {
-    const project = entry.sourceFile.getProject();
-    const declaration = getDeclarationByPath(project, declarationPath);
+    const declaration = getDeclarationByPath(entry, declarationPath);
 
     return {
       output: Node.isVariableDeclaration(declaration)

--- a/libs/builder/engine/nunjucks/actions/js-doc-tag.action.ts
+++ b/libs/builder/engine/nunjucks/actions/js-doc-tag.action.ts
@@ -10,8 +10,7 @@ import { NgDocAction } from '../../../types';
  */
 export function jsDocTagAction(declarationPath: string, tagName: string): NgDocAction<string> {
   return (entry) => {
-    const project = entry.sourceFile.getProject();
-    const declaration = getDeclarationByPath(project, declarationPath);
+    const declaration = getDeclarationByPath(entry, declarationPath);
 
     return {
       output: Node.isVariableDeclaration(declaration)

--- a/libs/builder/engine/nunjucks/actions/js-doc-tags.action.ts
+++ b/libs/builder/engine/nunjucks/actions/js-doc-tags.action.ts
@@ -10,8 +10,7 @@ import { NgDocAction } from '../../../types';
  */
 export function jsDocTagsAction(declarationPath: string, tagName: string): NgDocAction<string[]> {
   return (entry) => {
-    const project = entry.sourceFile.getProject();
-    const declaration = getDeclarationByPath(project, declarationPath);
+    const declaration = getDeclarationByPath(entry, declarationPath);
     const output = Node.isVariableDeclaration(declaration)
       ? getJsDocTags(declaration.getVariableStatement()!, tagName)
       : getJsDocTags(declaration, tagName);

--- a/libs/builder/engine/nunjucks/actions/js-doc.action.ts
+++ b/libs/builder/engine/nunjucks/actions/js-doc.action.ts
@@ -9,8 +9,7 @@ import { NgDocAction } from '../../../types';
  */
 export function jsDocAction(declarationPath: string): NgDocAction<string> {
   return (entry) => {
-    const project = entry.sourceFile.getProject();
-    const declaration = getDeclarationByPath(project, declarationPath);
+    const declaration = getDeclarationByPath(entry, declarationPath);
 
     return {
       output: Node.isVariableDeclaration(declaration)

--- a/libs/builder/helpers/build-file-entity.ts
+++ b/libs/builder/helpers/build-file-entity.ts
@@ -70,7 +70,7 @@ export async function buildFileEntity(
 	await esbuild.build({
 		stdin: {
 			contents: code,
-			resolveDir: path.dirname(p),
+			resolveDir: path.dirname(path.resolve(outbase, p)),
 			loader: 'ts',
 			sourcefile: p,
 		},

--- a/libs/builder/helpers/create-builder-context.ts
+++ b/libs/builder/helpers/create-builder-context.ts
@@ -29,7 +29,10 @@ export function createBuilderContext(
     'ng-doc',
     context.target?.project ?? 'app',
   );
-  const tsConfig = config?.tsConfig ?? String(targetOptions['tsConfig']);
+  const tsConfig = path.resolve(
+    context.workspaceRoot,
+    config?.tsConfig ?? String(targetOptions['tsConfig']),
+  );
 
   return {
     tsConfig,
@@ -37,7 +40,7 @@ export function createBuilderContext(
     config,
     context,
     inlineStyleLanguage: (targetOptions?.['inlineStyleLanguage'] as NgDocStyleType) ?? 'CSS',
-    docsPath: config.docsPath ?? projectRoot,
+    docsPath: path.resolve(context.workspaceRoot, config.docsPath ?? projectRoot),
     outAssetsDir: path.join(buildPath, 'assets'),
     cachedFiles: [configPath],
     outDir: buildPath,

--- a/libs/builder/helpers/get-declaration-by-path.ts
+++ b/libs/builder/helpers/get-declaration-by-path.ts
@@ -1,15 +1,47 @@
 import { NgDocSupportedDeclaration } from '@ng-doc/builder';
-import { Project } from 'ts-morph';
+import * as path from 'path';
+import { Project, SourceFile } from 'ts-morph';
 
+import { EntryMetadata } from '../engine/builders/interfaces/entry-metadata';
 import { isSupportedDeclaration } from './is-supported-declaration';
 
 /**
  *
+ * @param entry
+ * @param sourceFilePath
+ * @returns Array of potential path for the sourceFilePath.
+ */
+function getSearchPaths(entry: EntryMetadata, sourceFilePath: string): string[] {
+  const project = entry.sourceFile.getProject();
+  const compilerOptions = project.getCompilerOptions();
+  return [
+    compilerOptions.rootDir ? path.resolve(compilerOptions.rootDir, sourceFilePath) : undefined,
+    path.resolve(entry.dir, sourceFilePath),
+    sourceFilePath,
+  ].filter((p) => p != null);
+}
+
+/**
+ *
  * @param project
+ * @param searchPaths Array of path to search in order
+ * @returns SourceFile of first path found or undefined
+ */
+function getFirstSourceFile(project: Project, searchPaths: string[]): SourceFile | undefined {
+  for (const searchPath of searchPaths) {
+    const sourceFile = project.getSourceFile(searchPath);
+    if (sourceFile) return sourceFile;
+  }
+  return undefined;
+}
+
+/**
+ *
+ * @param entry
  * @param declarationPath
  */
 export function getDeclarationByPath(
-  project: Project,
+  entry: EntryMetadata,
   declarationPath: string,
 ): NgDocSupportedDeclaration {
   const [sourceFilePath, name] = declarationPath.split('#');
@@ -20,12 +52,15 @@ export function getDeclarationByPath(
     );
   }
 
-  let sourceFile = project.getSourceFile(sourceFilePath);
+  const project = entry.sourceFile.getProject();
+
+  const searchPaths = getSearchPaths(entry, sourceFilePath);
+  let sourceFile = getFirstSourceFile(project, searchPaths);
 
   sourceFile?.refreshFromFileSystemSync();
 
   if (!sourceFile) {
-    sourceFile = project.addSourceFileAtPath(sourceFilePath);
+    sourceFile = project.addSourceFileAtPath(searchPaths[0]);
   }
 
   const declarationNodes = sourceFile.getExportedDeclarations().get(name);

--- a/libs/builder/interfaces/configuration.ts
+++ b/libs/builder/interfaces/configuration.ts
@@ -39,7 +39,8 @@ export interface NgDocConfiguration {
    */
   repoConfig?: NgDocRepoConfig;
   /**
-   * The path to the tsconfig file (NgDoc uses tsconfig of your application by default, but you can override it)
+   * The path to the tsconfig file (NgDoc uses tsconfig of your application by default, but you can override it).
+   * The path must be relative to the Angular workspace root (the directory containing `angular.json`).
    */
   tsConfig?: string;
   /**


### PR DESCRIPTION

Three places were resolving paths relative to current working directory:

- tsConfig passed to ts-morph
- resolveDir passed to esbuild in build-file-entity
- Declaration paths in getDeclarationByPath (JSDoc/NgDocApi markdown actions)

I just changed to resolve absolute path based on Angular workspace root. The more complicated fix was getDeclarationByPath where is didn't readily have access to the workspace root. So I used the tsconfig rootDir which should be fine. I kept the fallback to untouched path just in case and added resolution relative to the path as a bonus.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI-related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number

<!-- Bugs and features must be linked to an issue. -->

Issue Number: #330 

## Does this PR introduce a breaking change?

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
